### PR TITLE
Clean up Glide cache directory after saving manipulated image

### DIFF
--- a/src/GlideConversion.php
+++ b/src/GlideConversion.php
@@ -95,7 +95,11 @@ final class GlideConversion
             return;
         }
 
+        $conversionResultDirectory = pathinfo($this->conversionResult, PATHINFO_DIRNAME);
+
         rename($this->conversionResult, $outputFile);
+
+        rmdir($conversionResultDirectory);
     }
 
     private function prepareManipulations(array $manipulationGroup): array


### PR DESCRIPTION
The Glide cache folder (`sys_get_temp_dir()` is used for this project by default) gets bloated with manipulation result directories; as this is the default behaviour of Glide (see http://glide.thephpleague.com/1.0/config/source-and-cache/). 

When manipulating lots of images, `sys_get_temp_dir()` gets clogged with folders and (in our case) touching the limits of filesystems (number of inodes allocated). We are getting random "No free space left on device" errors because of this.

This patch deletes the directory Glide created after saving the manipulated image.