### PR TITLE
Fixes possible empty manipulation groups while iterating over a ManipulationSequence instance

### DIFF
--- a/src/ManipulationSequence.php
+++ b/src/ManipulationSequence.php
@@ -52,7 +52,9 @@ class ManipulationSequence implements IteratorAggregate
                 $this->addManipulation($name, $argument);
             }
 
-            $this->startNewGroup();
+            if (next($sequenceArray)) {
+                $this->startNewGroup();
+            }
         }
     }
 
@@ -78,7 +80,7 @@ class ManipulationSequence implements IteratorAggregate
 
     public function getIterator(): ArrayIterator
     {
-        return new ArrayIterator($this->groups);
+        return new ArrayIterator($this->toArray());
     }
 
     /**

--- a/tests/ManipulationSequenceTest.php
+++ b/tests/ManipulationSequenceTest.php
@@ -240,4 +240,26 @@ class ManipulationSequenceTest extends TestCase
 
         $this->assertEquals($sequenceArray, $sequence->toArray());
     }
+
+    /** @test */
+    public function it_does_not_return_empty_groups_when_iterating_a_merged_sequence()
+    {
+        $sequenceArray = [
+            [
+                'width' => 100,
+                'height' => 100,
+            ],
+        ];
+
+        $sequence1 = new ManipulationSequence();
+        $sequence2 = new ManipulationSequence($sequenceArray);
+
+        $mergedSequence = $sequence1->merge($sequence2);
+
+        $this->assertCount(1, $mergedSequence);
+
+        foreach ($mergedSequence as $sequence) {
+            $this->assertEquals($sequenceArray[0], $sequence);
+        }
+    }
 }


### PR DESCRIPTION
When iterating over a ManipulationSequence instance (which happens at [here](https://github.com/spatie/image/blob/master/src/GlideConversion.php#L40) for example), one iterates the "raw" groups array of ManipulationSequence. If this array has been merged, which always happens [here](https://github.com/spatie/image/blob/master/src/Image.php#L67) because [`Image` sets $this->manipulations to a new instance of `Manipulations`](https://github.com/spatie/image/blob/master/src/Image.php#L34) , an empty group is yielded. 

This causes `GlideConversion::performManipulations` to run a manipulation that makes no sense. I guess this was not noticed earlier because the tests nicely use `ManipulationSequence::toArray` and Glide does not trigger an error when it's called without any manipulation arguments.

This patch ensures no new group is being added if this is not necessary and it returns a new `ArrayIterator` of the result of `ManipulationSequence::toArray`.