### PR TITLE
Update Manipulations.php to let manipulations arrays also

### DIFF
--- a/src/Manipulations.php
+++ b/src/Manipulations.php
@@ -59,7 +59,7 @@ class Manipulations
 
     public function __construct(array $manipulations = [])
     {
-        if (!$this->hasMultipleConversions($manipulations)) {
+        if (! $this->hasMultipleConversions($manipulations)) {
             $manipulations = [$manipulations];
         }
 
@@ -564,7 +564,7 @@ class Manipulations
     /**
      * Create new manipulations class.
      *
-     * @param Array $manipulations
+     * @param array $manipulations
      *
      * @return self
      */
@@ -573,8 +573,7 @@ class Manipulations
         return new self($manipulations);
     }
 
-    
-    public function toArray()
+    public function toArray() : array
     {
         return $this->manipulationSequence->toArray();
     }

--- a/src/Manipulations.php
+++ b/src/Manipulations.php
@@ -59,7 +59,14 @@ class Manipulations
 
     public function __construct(array $manipulations = [])
     {
-        $this->manipulationSequence = new ManipulationSequence($manipulations);
+        //Check if is a single array or multi arrays
+        if ($this->checkIfHasMultipleConversions($manipulations)) {
+            foreach ($manipulations as $manipulation) {
+                $this->manipulationSequence = new ManipulationSequence($manipulation);
+            }
+        } else {
+            $this->manipulationSequence = new ManipulationSequence($manipulations);
+        }
     }
 
     /**
@@ -553,6 +560,43 @@ class Manipulations
         $this->manipulationSequence->startNewGroup();
 
         return $this;
+    }
+
+    /**
+     * Create new manipulations class
+     *
+     * @return self
+     */
+    public static function create()
+    {
+        return new self();
+    }
+
+    /**
+     * Return manipulationSequence as array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->manipulationSequence->toArray();
+    }
+
+    /**
+     * Checks if the given manipulations has arrays inside or not
+     *
+     * @param  Array $manipulations
+     * @return bool
+     */
+    private function checkIfHasMultipleConversions($manipulations)
+    {
+        $hasArrays = false;
+        foreach ($manipulations as $manipulation) {
+            if (isset($manipulation[0]) && is_array($manipulation[0])) {
+                $hasArrays = true;
+            }
+        }
+        return $hasArrays;
     }
 
     public function removeManipulation(string $name)

--- a/src/Manipulations.php
+++ b/src/Manipulations.php
@@ -59,13 +59,12 @@ class Manipulations
 
     public function __construct(array $manipulations = [])
     {
-        //Check if is a single array or multi arrays
-        if ($this->checkIfHasMultipleConversions($manipulations)) {
-            foreach ($manipulations as $manipulation) {
-                $this->manipulationSequence = new ManipulationSequence($manipulation);
-            }
-        } else {
-            $this->manipulationSequence = new ManipulationSequence($manipulations);
+        if (!$this->hasMultipleConversions($manipulations)) {
+            $manipulations = [$manipulations];
+        }
+
+        foreach ($manipulations as $manipulation) {
+            $this->manipulationSequence = new ManipulationSequence($manipulation);
         }
     }
 
@@ -563,40 +562,38 @@ class Manipulations
     }
 
     /**
-     * Create new manipulations class
+     * Create new manipulations class.
+     *
+     * @param Array $manipulations
      *
      * @return self
      */
-    public static function create()
+    public static function create(array $manipulations = [])
     {
-        return new self();
+        return new self($manipulations);
     }
 
-    /**
-     * Return manipulationSequence as array
-     *
-     * @return array
-     */
+    
     public function toArray()
     {
         return $this->manipulationSequence->toArray();
     }
 
     /**
-     * Checks if the given manipulations has arrays inside or not
+     * Checks if the given manipulations has arrays inside or not.
      *
-     * @param  Array $manipulations
+     * @param  array $manipulations
+     *
      * @return bool
      */
-    private function checkIfHasMultipleConversions($manipulations)
+    private function hasMultipleConversions(array $manipulations) : bool
     {
-        $hasArrays = false;
         foreach ($manipulations as $manipulation) {
             if (isset($manipulation[0]) && is_array($manipulation[0])) {
-                $hasArrays = true;
+                return true;
             }
         }
-        return $hasArrays;
+        return false;
     }
 
     public function removeManipulation(string $name)

--- a/tests/ManipulationsTest.php
+++ b/tests/ManipulationsTest.php
@@ -44,6 +44,65 @@ class ManipulationsTest extends TestCase
     }
 
     /** @test */
+    public function it_can_be_constructed_with_a_single_sequence()
+    {
+        $sequenceArray = [
+            [
+                'filter' => 'greyscale',
+                'width' => 50,
+            ],
+        ];
+
+        $manipulations = (new Manipulations($sequenceArray));
+
+        $this->assertEquals($sequenceArray, $manipulations->getManipulationSequence()->toArray());
+    }
+
+    /** @test */
+    public function it_can_return_an_array_of_manipulations()
+    {
+        $sequenceArray = [
+            ['width' => "123"],
+            ['manualCrop' => '20,10,10,10'],
+        ];
+
+        $manipulations = Manipulations::create()
+            ->width(123)
+            ->apply()
+            ->manualCrop(20, 10, 10, 10);
+
+        $this->assertEquals($sequenceArray, $manipulations->toArray());
+    }
+
+    /** @test */
+    public function it_can_create_from_sequence_array()
+    {
+        $sequenceArray = [
+            ['width' => "123"],
+            ['manualCrop' => '20,10,10,10'],
+        ];
+        
+        $manipulations = Manipulations::create($sequenceArray);
+
+        $this->assertEquals($sequenceArray, $manipulations->toArray());
+    }
+
+    /** @test */
+    public function it_can_create_from_single_sequence()
+    {
+        $sequence = [
+            [
+                'manualCrop' => '20,10,10,10',
+                'width' => "123",
+            ]
+        ];
+
+        $manipulations = Manipulations::create($sequence);
+
+        $this->assertEquals($sequence, $manipulations->toArray());
+    }
+
+    /** @test */
     public function it_can_merge_itself_with_another_instance()
     {
         $manipulations1 = (new Manipulations())

--- a/tests/ManipulationsTest.php
+++ b/tests/ManipulationsTest.php
@@ -62,7 +62,7 @@ class ManipulationsTest extends TestCase
     public function it_can_return_an_array_of_manipulations()
     {
         $sequenceArray = [
-            ['width' => "123"],
+            ['width' => '123'],
             ['manualCrop' => '20,10,10,10'],
         ];
 
@@ -78,7 +78,7 @@ class ManipulationsTest extends TestCase
     public function it_can_create_from_sequence_array()
     {
         $sequenceArray = [
-            ['width' => "123"],
+            ['width' => '123'],
             ['manualCrop' => '20,10,10,10'],
         ];
         
@@ -93,7 +93,7 @@ class ManipulationsTest extends TestCase
         $sequence = [
             [
                 'manualCrop' => '20,10,10,10',
-                'width' => "123",
+                ['width' => '123'],
             ]
         ];
 

--- a/tests/ManipulationsTest.php
+++ b/tests/ManipulationsTest.php
@@ -93,7 +93,7 @@ class ManipulationsTest extends TestCase
         $sequence = [
             [
                 'manualCrop' => '20,10,10,10',
-                ['width' => '123'],
+                'width' => '123',
             ]
         ];
 


### PR DESCRIPTION
WIth this fix you can send a normal manipulation:

```php
$media->manipulations = [
    'resized' =>['width' => 123, 'height' => 123],
];
```

And also this kind of manipulations:

```php
$resizedConversion = Manipulations::create()
    ->width(123)
    ->apply()
    ->manualCrop(20, 20, 10, 10);

$media->manipulations = [
    'resized' => $resizedConversion->toArray()
];

```