### PR TITLE
Use copy() & unlink() instead of rename()

### DIFF
--- a/src/GlideConversion.php
+++ b/src/GlideConversion.php
@@ -98,7 +98,8 @@ final class GlideConversion
 
         $conversionResultDirectory = pathinfo($this->conversionResult, PATHINFO_DIRNAME);
 
-        rename($this->conversionResult, $outputFile);
+        copy($this->conversionResult, $outputFile);
+        unlink($this->conversionResult);
 
         if ($this->directoryIsEmpty($conversionResultDirectory)) {
             rmdir($conversionResultDirectory);


### PR DESCRIPTION
`rename()` will produce warnings and `GlideConversion` will throw an `ErrorException` if it is used across different volumes/disks so a simpler solution would be to break it in two parts using `copy()` and `unlink()`.

This is the cause behind https://github.com/spatie/laravel-medialibrary/issues/588 but changing PHP's `tmp` directory may not always be possible (or convenient), so this is why I'm submitting this PR.