### PR TITLE
makes __construct private

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -28,7 +28,7 @@ class Image
         return new static($pathToImage);
     }
 
-    public function __construct(string $pathToImage)
+    private function __construct(string $pathToImage)
     {
         $this->pathToImage = $pathToImage;
 


### PR DESCRIPTION
A private `__construct` forces the usage of the `load` static method.