### PR TITLE
The 'shouldOptimize' function returned true when no optimizations were set

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -125,7 +125,8 @@ class Image
 
     protected function shouldOptimize(): bool
     {
-        return ! is_null($this->manipulations->getFirstManipulationArgument('optimize'));
+        $optimizations = $this->manipulations->getFirstManipulationArgument('optimize');
+        return ! is_null($optimizations) && $optimizations != '[]';
     }
 
     protected function performOptimization($path, array $optimizerChainConfiguration)

--- a/src/Image.php
+++ b/src/Image.php
@@ -126,6 +126,7 @@ class Image
     protected function shouldOptimize(): bool
     {
         $optimizations = $this->manipulations->getFirstManipulationArgument('optimize');
+        
         return ! is_null($optimizations) && $optimizations != '[]';
     }
 


### PR DESCRIPTION
The 'shouldOptimize' function returned true when no optimizations were set

Our clients hosting provider blocks the 'proc_open' function required by the optimizations, tried to work around this by removing all optimizers, but this didn't work because of this issue.