### PR TITLE
Change GlideConversion sequence

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -119,13 +119,13 @@ class Image
 
         $this->addFormatManipulation($outputPath);
 
-        $glideConversion = GlideConversion::create($this->pathToImage)
-            ->useImageDriver($this->imageDriver)
-            ->performManipulations($this->manipulations);
+        $glideConversion = GlideConversion::create($this->pathToImage)->useImageDriver($this->imageDriver);
 
         if (! is_null($this->temporaryDirectory)) {
             $glideConversion->setTemporaryDirectory($this->temporaryDirectory);
         }
+        
+        $glideConversion->performManipulations($this->manipulations);
 
         $glideConversion->save($outputPath);
 


### PR DESCRIPTION
Temporary directory setting is now after GlideConversion creation and before image manipulations, so that setting a custom temporary directory on an Image object (via Image->setTemporaryDirectory()) has the expected effect.