### PR TITLE
Update badge alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Manipulate images with an expressive API
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/image.svg?style=flat-square)](https://packagist.org/packages/spatie/image)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/spatie/image/master.svg?style=flat-square)](https://travis-ci.org/spatie/image)
 [![Quality Score](https://img.shields.io/scrutinizer/g/spatie/image.svg?style=flat-square)](https://scrutinizer-ci.com/g/spatie/image)
 [![StyleCI](https://styleci.io/repos/80513668/shield?branch=master)](https://styleci.io/repos/80513668)


### PR DESCRIPTION
If the bade doesn't load, this will still allow users to see what the license is. It is also beneficial for users who use screen readers.

See also: https://github.com/spatie/laravel-sluggable/pull/107