### PR TITLE
change uppercase function to mb_strtoupper instead of strtoupper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.0",
         "ext-exif": "*",
+        "ext-mbstring": "*",
         "league/glide": "^1.4",
         "spatie/image-optimizer": "^1.0",
         "spatie/temporary-directory": "^1.0.0",
@@ -43,5 +44,5 @@
     },
     "config": {
         "sort-packages": true
-  }
+    }
 }

--- a/src/Manipulations.php
+++ b/src/Manipulations.php
@@ -686,7 +686,7 @@ class Manipulations
         $options = (new ReflectionClass(static::class))->getConstants();
 
         return array_filter($options, function ($value, $name) use ($manipulation) {
-            return strpos($name, strtoupper($manipulation)) === 0;
+            return strpos($name, mb_strtoupper($manipulation)) === 0;
         }, ARRAY_FILTER_USE_BOTH);
     }
 


### PR DESCRIPTION
`strtoupper('fit')` returns `FİT` when language set to Turkish.

`$this->addMediaConversion('test')->fit(Manipulations::FIT_CROP, 64,64)->performOnCollections('test')` throwing InvalidManipulation all the time.

`mb_strtoupper('fit')` workings corrects and returns `FIT`.

Fixes #98 
