### PR TITLE
Allow usage of a custom `OptimizerChain` (#106)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-exif": "*",
         "ext-mbstring": "*",
         "league/glide": "^1.4",
-        "spatie/image-optimizer": "^1.0",
+        "spatie/image-optimizer": "^1.1",
         "spatie/temporary-directory": "^1.0.0",
         "symfony/process": "^3.0|^4.0|^5.0"
     },

--- a/docs/image-manipulations/optimizing-images.md
+++ b/docs/image-manipulations/optimizing-images.md
@@ -37,3 +37,18 @@ Image::load('example.jpg')
     ]])
     ->save();
 ```
+
+If you need more control over the optimizer chain, you can still pass your own instance of `OptimizerChain`. It can be especially useful if you need to set a custom timeout or a custom binary path. You may not have enough privileges to install the necessary binaries on your server but you can still upload some [precompiled binaries](https://github.com/imagemin?q=bin&type=&language=).
+
+```php
+$optimizer = new OptimizerChain();
+$optimizer->setTimeout(10);
+$optimizer->addOptimizer(new Jpegoptim([
+    '--all-progressive',
+])->setBinaryPath('/home/user/bin/jpegoptim'));
+
+Image::load('example.jpg')
+    ->setOptimizeChain($optimizer)
+    ->optimize()
+    ->save();
+```

--- a/src/Image.php
+++ b/src/Image.php
@@ -167,7 +167,7 @@ class Image
                     return get_class($optimizer) === $optimizerClassName;
                 });
 
-                $optimizer = count($optimizer) > 0 && $optimizer[0] instanceof BaseOptimizer ? $optimizer[0] : (new $optimizerClassName);
+                $optimizer = count($optimizer) > 0 && $optimizer[0] instanceof BaseOptimizer ? $optimizer[0] : new $optimizerClassName;
 
                 return $optimizer->setOptions($optimizerOptions)->setBinaryPath($optimizer->binaryPath);
             }, $optimizerChainConfiguration, array_keys($optimizerChainConfiguration));

--- a/src/Image.php
+++ b/src/Image.php
@@ -5,7 +5,9 @@ namespace Spatie\Image;
 use BadMethodCallException;
 use Intervention\Image\ImageManagerStatic as InterventionImage;
 use Spatie\Image\Exceptions\InvalidImageDriver;
+use Spatie\ImageOptimizer\OptimizerChain;
 use Spatie\ImageOptimizer\OptimizerChainFactory;
+use Spatie\ImageOptimizer\Optimizers\BaseOptimizer;
 
 /** @mixin \Spatie\Image\Manipulations */
 class Image
@@ -21,6 +23,9 @@ class Image
     /** @var string|null */
     protected $temporaryDirectory = null;
 
+    /** @var OptimizerChain */
+    protected $optimizerChain;
+
     /**
      * @param string $pathToImage
      *
@@ -34,6 +39,13 @@ class Image
     public function setTemporaryDirectory($tempDir)
     {
         $this->temporaryDirectory = $tempDir;
+
+        return $this;
+    }
+
+    public function setOptimizeChain(OptimizerChain $optimizerChain)
+    {
+        $this->optimizerChain = $optimizerChain;
 
         return $this;
     }
@@ -145,11 +157,19 @@ class Image
 
     protected function performOptimization($path, array $optimizerChainConfiguration)
     {
-        $optimizerChain = OptimizerChainFactory::create();
+        $optimizerChain = $this->optimizerChain ?? OptimizerChainFactory::create();
 
         if (count($optimizerChainConfiguration)) {
-            $optimizers = array_map(function (array $optimizerOptions, string $optimizerClassName) {
-                return (new $optimizerClassName)->setOptions($optimizerOptions);
+            $existingOptimizers = $optimizerChain->getOptimizers();
+
+            $optimizers = array_map(function (array $optimizerOptions, string $optimizerClassName) use ($existingOptimizers) {
+                $optimizer = array_filter($existingOptimizers, function ($optimizer) use ($optimizerClassName) {
+                    return get_class($optimizer) === $optimizerClassName;
+                });
+
+                $optimizer = count($optimizer) > 0 && $optimizer[0] instanceof BaseOptimizer ? $optimizer[0] : (new $optimizerClassName);
+
+                return $optimizer->setOptions($optimizerOptions)->setBinaryPath($optimizer->binaryPath);
             }, $optimizerChainConfiguration, array_keys($optimizerChainConfiguration));
 
             $optimizerChain->setOptimizers($optimizers);

--- a/tests/Manipulations/OptimizeTest.php
+++ b/tests/Manipulations/OptimizeTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Image\Test\Manipulations;
 
 use Spatie\Image\Image;
 use Spatie\Image\Test\TestCase;
+use Spatie\ImageOptimizer\OptimizerChainFactory;
 use Spatie\ImageOptimizer\Optimizers\Jpegoptim;
 
 class OptimizeTest extends TestCase
@@ -39,6 +40,21 @@ class OptimizeTest extends TestCase
         $targetFile = $this->tempDir->path('optimized.jpg');
 
         Image::load($this->getTestFile('test.jpg'))
+            ->optimize([Jpegoptim::class => [
+                '--all-progressive',
+            ]])
+            ->save($targetFile);
+
+        $this->assertFileExists($targetFile);
+    }
+
+    /** @test */
+    public function it_can_optimize_an_image_using_a_provided_optimizer_chain()
+    {
+        $targetFile = $this->tempDir->path('optimized.jpg');
+
+        Image::load($this->getTestFile('test.jpg'))
+            ->setOptimizeChain(OptimizerChainFactory::create())
             ->optimize([Jpegoptim::class => [
                 '--all-progressive',
             ]])


### PR DESCRIPTION
After some thinking about #106, not only `binaryPath` could be customized. 

`OptimizerChain` also has some others options such as `setTimeout` so one should be able to pass a custom `OptimizerChain`. 

`performOptimization` is reusing/updating existing `BaseOptimizer` instances, if they exist, instead of creating new ones.