### PR TITLE
change condition to delete $conversionResultDirectory

### DIFF
--- a/src/GlideConversion.php
+++ b/src/GlideConversion.php
@@ -144,7 +144,7 @@ final class GlideConversion
 
         unlink($this->conversionResult);
 
-        if ($this->directoryIsEmpty($conversionResultDirectory) && $conversionResultDirectory !== '/tmp') {
+        if ($this->directoryIsEmpty($conversionResultDirectory) && $conversionResultDirectory !== sys_get_temp_dir()) {
             rmdir($conversionResultDirectory);
         }
     }


### PR DESCRIPTION
This prevents the method from deleting the temp folder in some cases.

Maybe deleting the whole condition is an option too?

More: #117 