### PR TITLE
add avif support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 build
 composer.lock
 vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 build
 composer.lock
 vendor

--- a/src/Image.php
+++ b/src/Image.php
@@ -171,7 +171,7 @@ class Image
             return;
         }
 
-        $supportedFormats = ['jpg', 'pjpg', 'png', 'gif', 'webp'];
+        $supportedFormats = ['jpg', 'pjpg', 'png', 'gif', 'webp', 'avif'];
 
         if (in_array($outputExtension, $supportedFormats)) {
             $this->manipulations->format($outputExtension);

--- a/src/Manipulations.php
+++ b/src/Manipulations.php
@@ -42,6 +42,7 @@ class Manipulations
     public const FORMAT_PNG = 'png';
     public const FORMAT_GIF = 'gif';
     public const FORMAT_WEBP = 'webp';
+    public const FORMAT_AVIF = 'avif';
 
     public const FILTER_GREYSCALE = 'greyscale';
     public const FILTER_SEPIA = 'sepia';

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -60,6 +60,20 @@ class ImageTest extends TestCase
             Image::load($this->getTestJpg())->save($targetFile);
             $this->assertImageType($targetFile, IMAGETYPE_WEBP);
         }
+
+        //test avif format with gd driver
+        if (function_exists('imagecreatefromavif')) {
+            $targetFile= $this->tempDir->path('conversion.avif');
+            Image::load($this->getTestJpg())->save($targetFile);
+            $this->assertImageType($targetFile, IMAGETYPE_AVIF);
+        }
+        //test avif format with imagik
+        if (!empty(\Imagick::queryFormats("AVIF*"))){
+            $targetFile= $this->tempDir->path('conversion.avif');
+            Image::load($this->getTestJpg())->useImageDriver('imagick')->save($targetFile);
+            $image = new \Imagick($targetFile);
+            $this->assertSame("AVIF", $image->getImageFormat());
+        }
     }
 
     /** @test */

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Image\Test;
 use Intervention\Image\ImageManagerStatic as InterventionImage;
 use Spatie\Image\Image;
 use Spatie\Image\Manipulations;
+use Imagick;
 
 class ImageTest extends TestCase
 {
@@ -63,16 +64,17 @@ class ImageTest extends TestCase
 
         //test avif format with gd driver
         if (function_exists('imagecreatefromavif')) {
-            $targetFile= $this->tempDir->path('conversion.avif');
+            $targetFile = $this->tempDir->path('conversion.avif');
             Image::load($this->getTestJpg())->save($targetFile);
             $this->assertImageType($targetFile, IMAGETYPE_AVIF);
         }
-        //test avif format with imagik
-        if (!empty(\Imagick::queryFormats("AVIF*"))){
-            $targetFile= $this->tempDir->path('conversion.avif');
+        
+        //test avif format with imagick
+        if (!empty(Imagick::queryFormats('AVIF*'))){
+            $targetFile = $this->tempDir->path('conversion.avif');
             Image::load($this->getTestJpg())->useImageDriver('imagick')->save($targetFile);
-            $image = new \Imagick($targetFile);
-            $this->assertSame("AVIF", $image->getImageFormat());
+            $image = new Imagick($targetFile);
+            $this->assertSame('AVIF', $image->getImageFormat());
         }
     }
 


### PR DESCRIPTION
supporting from avif format is requested long time ago: in https://github.com/spatie/image/issues/137 and https://github.com/spatie/image/issues/92 in one of my project i really want to use avif format with https://github.com/spatie/laravel-medialibrary so i created this PR to add this format to the supported format list.

libgd started to support avif from version 2.3.2 using libavif 
and according to this blog post it will be available to the php users since php 8.1 [PHP 8.1: GD: AVIF image support](https://php.watch/versions/8.1/gd-avif)

imagemagick start supporting from avif format using libheif since version 7.0.25 

i've added test for both gd and imagick driver but i only test imagick with ImageMagick version  7.1.0-12 Q16-HDRI x86_64 2021-10-24