### PR TITLE
Add TIFF support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-exif": "*",
         "ext-mbstring": "*",
         "ext-json": "*",
-        "league/glide": "^2.0",
+        "league/glide": "^2.2.2",
         "spatie/image-optimizer": "^1.1",
         "spatie/temporary-directory": "^1.0|^2.0",
         "symfony/process": "^3.0|^4.0|^5.0|^6.0"

--- a/docs/usage/saving-images.md
+++ b/docs/usage/saving-images.md
@@ -21,7 +21,7 @@ Image::load('example.jpg')
 
 ## Saving in a different image format
 
-To save your image as a different image format call the `format` method and pass in the desired format. Currently the following formats are supported: `FORMAT_JPG`, `FORMAT_PJPG`, `FORMAT_PNG`, `FORMAT_GIF` and `FORMAT_WEBP`.
+To save your image as a different image format call the `format` method and pass in the desired format. Currently the following formats are supported: `FORMAT_JPG`, `FORMAT_PJPG`, `FORMAT_PNG`, `FORMAT_GIF`, `FORMAT_WEBP` and `FORMAT_TIFF`.
 
 ```php
 Image::load('example.jpg')

--- a/src/Image.php
+++ b/src/Image.php
@@ -171,7 +171,18 @@ class Image
             return;
         }
 
-        $supportedFormats = ['jpg', 'pjpg', 'png', 'gif', 'webp', 'avif'];
+        $supportedFormats = [
+            Manipulations::FORMAT_JPG,
+            Manipulations::FORMAT_PJPG,
+            Manipulations::FORMAT_PNG,
+            Manipulations::FORMAT_GIF,
+            Manipulations::FORMAT_WEBP,
+            Manipulations::FORMAT_AVIF,
+        ];
+        //gd driver doesn't support TIFF
+        if ($this->imageDriver === 'imagick') {
+            $supportedFormats[] = Manipulations::FORMAT_TIFF;
+        }
 
         if (in_array($outputExtension, $supportedFormats)) {
             $this->manipulations->format($outputExtension);

--- a/src/Manipulations.php
+++ b/src/Manipulations.php
@@ -43,6 +43,7 @@ class Manipulations
     public const FORMAT_GIF = 'gif';
     public const FORMAT_WEBP = 'webp';
     public const FORMAT_AVIF = 'avif';
+    public const FORMAT_TIFF = 'tiff';
 
     public const FILTER_GREYSCALE = 'greyscale';
     public const FILTER_SEPIA = 'sepia';

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -109,6 +109,8 @@ class ImageTest extends TestCase
     {
         $image = Image::load($this->getTestJpg());
 
+        $image->useImageDriver('gd');
+
         $this->assertSame('gd', InterventionImage::getManager()->config['driver'] ?? null);
 
         $image->useImageDriver('imagick');

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -76,6 +76,14 @@ class ImageTest extends TestCase
             $image = new Imagick($targetFile);
             $this->assertSame('AVIF', $image->getImageFormat());
         }
+
+        //test tiff format with imagick
+        if (!empty(Imagick::queryFormats('TIFF*'))) {
+            $targetFile = $this->tempDir->path('conversion.tiff');
+            Image::load($this->getTestJpg())->useImageDriver('imagick')->save($targetFile);
+            $image = new Imagick($targetFile);
+            $this->assertSame('TIFF', $image->getImageFormat());
+        }
     }
 
     /** @test */

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -78,7 +78,7 @@ class ImageTest extends TestCase
         }
 
         //test tiff format with imagick
-        if (!empty(Imagick::queryFormats('TIFF*'))) {
+        if (! empty(Imagick::queryFormats('TIFF*'))) {
             $targetFile = $this->tempDir->path('conversion.tiff');
             Image::load($this->getTestJpg())->useImageDriver('imagick')->save($targetFile);
             $image = new Imagick($targetFile);


### PR DESCRIPTION
Now that [Glide's TIFF support is fixed](https://github.com/thephpleague/glide/releases/tag/2.2.2), I can submit this PR to support [the discussion in Media Library](https://github.com/spatie/laravel-medialibrary/discussions/2794)!