### PR TITLE
Fix permission issue with temporary directory

### DIFF
--- a/src/GlideConversion.php
+++ b/src/GlideConversion.php
@@ -128,7 +128,7 @@ final class GlideConversion
 
         unlink($this->conversionResult);
 
-        if ($this->directoryIsEmpty($conversionResultDirectory) && $conversionResultDirectory !== sys_get_temp_dir()) {
+        if ($conversionResultDirectory !== sys_get_temp_dir() && $this->directoryIsEmpty($conversionResultDirectory)) {
             rmdir($conversionResultDirectory);
         }
     }


### PR DESCRIPTION
This pull request fixes an exception that i got on a shared webspace (where I'm not able to read the contents of the `/tmp` directory):

```
Failed to open directory: Permission denied at [...]/vendor/spatie/image/src/GlideConversion.php:185
```