### PR TITLE
Add zero orientation support ignoring EXIF

### DIFF
--- a/src/Manipulations.php
+++ b/src/Manipulations.php
@@ -19,6 +19,7 @@ class Manipulations
     public const CROP_BOTTOM_RIGHT = 'crop-bottom-right';
 
     public const ORIENTATION_AUTO = 'auto';
+    public const ORIENTATION_0 = 0;
     public const ORIENTATION_90 = 90;
     public const ORIENTATION_180 = 180;
     public const ORIENTATION_270 = 270;


### PR DESCRIPTION
Problem: 
As some images have an EXIF orientation, I had the problem with rotating an image to its default orientation without EXIF. I just needed the EXIF orientation data to be ignored/deleted.

Solution:
Glide supports zero orientation to rotate an image in the same orientation as before but ignoring the EXIF orientation.


This PR adds the possibility to rotate an image by zero, deleting EXIF orientation.