### PR TITLE
Enable `timeout` setting for the `optimize` method

### DIFF
--- a/docs/image-manipulations/optimizing-images.md
+++ b/docs/image-manipulations/optimizing-images.md
@@ -28,22 +28,31 @@ No matter where or how many times you call `optimize` in you chain, it will alwa
 
 ## Customizing the optimization
 
-You are able to customize the optimization by passing an options array to the `optimize` method:
-- `'timeout'` settings key lets you to set a custom timeout in seconds other than the default 60s. Adjusting this setting may be inevitable while working with large images (see e.g. [#187](https://github.com/spatie/image/pull/187))
-- `'optimizers'` settings key lets you to pass your own customized chain of optimizers as an array. The keys should be fully qualified class names of optimizers and the values should be the options that they should get
-
-Here's an example:
+You are able to customize the optimization by passing an options array to the `optimize` method. The `'optimizers'` settings key lets you to pass your own customized chain of optimizers as an array. The keys should be fully qualified class names of optimizers and the values should be the options that they should get.
 
 ```php
 Image::load('example.jpg')
     ->optimize([
-        'timeout' => 120,
         'optimizers' => [
             Jpegoptim::class => [
                 '--all-progressive',
             ],
         ],
     ])
+    ->save();
+```
+
+Besides the options array you may pass the `$timeout` argument. It lets you to set a custom timeout in seconds other than the default 60s. Adjusting this setting may be inevitable while working with large images (see e.g. [#187](https://github.com/spatie/image/pull/187)).
+
+```php
+Image::load('example.jpg')
+    ->optimize([
+        'optimizers' => [
+            Jpegoptim::class => [
+                '--all-progressive',
+            ],
+        ],
+    ], timeout: 120)
     ->save();
 ```
 

--- a/docs/image-manipulations/optimizing-images.md
+++ b/docs/image-manipulations/optimizing-images.md
@@ -5,7 +5,7 @@ weight: 3
 
 ## Requirements
 
-Optimization of images is done by the underlying [spatie/image-optimizer](https://github.com/spatie/image-optimizer). It assumes that there are a few optimization tools, such as [JpegOptim](http://freecode.com/projects/jpegoptim) an [Pngquant](https://pngquant.org/) present on your system. For more info, check out [the relevant docs](https://github.com/spatie/image-optimizer#optimization-tools).
+Optimization of images is done by the underlying [spatie/image-optimizer](https://github.com/spatie/image-optimizer) package. It assumes that there are a few optimization tools, such as [JpegOptim](http://freecode.com/projects/jpegoptim) an [Pngquant](https://pngquant.org/) present on your system. For more info, check out [the relevant docs](https://github.com/spatie/image-optimizer#optimization-tools).
 
 ## How to use
 
@@ -28,17 +28,26 @@ No matter where or how many times you call `optimize` in you chain, it will alwa
 
 ## Customizing the optimization
 
-To optimization of images is done by the underlying [spatie/image-optimizer](https://github.com/spatie/image-optimizer) package. You can pass your own customized chains as array. The keys should be fully qualified class names of optimizers and the values the options that they should get. Here's an example
+You are able to customize the optimization by passing an options array to the `optimize` method:
+- `'timeout'` settings key lets you to set a custom timeout in seconds other than the default 60s. Adjusting this setting may be inevitable while working with large images (see e.g. [#187](https://github.com/spatie/image/pull/187))
+- `'optimizers'` settings key lets you to pass your own customized chain of optimizers as an array. The keys should be fully qualified class names of optimizers and the values should be the options that they should get
+
+Here's an example:
 
 ```php
 Image::load('example.jpg')
-    ->optimize([Jpegoptim::class => [
-        '--all-progressive',
-    ]])
+    ->optimize([
+        'timeout' => 120,
+        'optimizers' => [
+            Jpegoptim::class => [
+                '--all-progressive',
+            ],
+        ],
+    ])
     ->save();
 ```
 
-If you need more control over the optimizer chain, you can still pass your own instance of `OptimizerChain`. It can be especially useful if you need to set a custom timeout or a custom binary path. You may not have enough privileges to install the necessary binaries on your server but you can still upload some [precompiled binaries](https://github.com/imagemin?q=bin&type=&language=).
+If you need more control over the optimizer chain, you can still pass your own instance of `OptimizerChain`. It can be especially useful if you need to set a custom binary path. You may not have enough privileges to install the necessary binaries on your server but you can still upload some [precompiled binaries](https://github.com/imagemin?q=bin&type=&language=).
 
 ```php
 $optimizer = new OptimizerChain();

--- a/src/Image.php
+++ b/src/Image.php
@@ -140,8 +140,15 @@ class Image
         $optimizerChain = $this->optimizerChain ?? OptimizerChainFactory::create();
 
         if (count($optimizerChainConfiguration)) {
+            if (isset($optimizerChainConfiguration['timeout'])) {
+                $optimizerChain->setTimeout($optimizerChainConfiguration['timeout']);
+                // unsetting the 'timeout' key for the backward compatibility for configuration arrays not having the 'optimizers' key
+                unset($optimizerChainConfiguration['timeout']);
+            }
+
             $optimizersOptions = isset($optimizerChainConfiguration['optimizers'])
                 ? $optimizerChainConfiguration['optimizers']
+                // backward compatibility for configuration arrays not having the 'optimizers' key
                 : $optimizerChainConfiguration;
             $existingOptimizers = $optimizerChain->getOptimizers();
             $optimizers = array_map(function (array $optimizerOptions, string $optimizerClassName) use ($existingOptimizers) {
@@ -155,10 +162,6 @@ class Image
             }, $optimizersOptions, array_keys($optimizersOptions));
 
             $optimizerChain->setOptimizers($optimizers);
-
-            if (isset($optimizerChainConfiguration['timeout'])) {
-                $optimizerChain->setTimeout($optimizerChainConfiguration['timeout']);
-            }
         }
 
         $optimizerChain->optimize($path);

--- a/src/Manipulations.php
+++ b/src/Manipulations.php
@@ -508,8 +508,12 @@ class Manipulations
     /**
      * Shave off some kilobytes by optimizing the image.
      */
-    public function optimize(array $optimizationOptions = []): static
+    public function optimize(array $optimizationOptions = [], ?int $timeout = null): static
     {
+        if ($timeout !== null) {
+            $optimizationOptions['timeout'] = $timeout;
+        }
+
         return $this->addManipulation('optimize', json_encode($optimizationOptions));
     }
 

--- a/tests/Manipulations/OptimizeTest.php
+++ b/tests/Manipulations/OptimizeTest.php
@@ -49,7 +49,7 @@ it('can optimize an image with options format backward compatibility', function 
 
     Image::load(getTestFile('test.jpg'))
         ->optimize([Jpegoptim::class => [
-        '--all-progressive',
+            '--all-progressive',
         ]])
         ->save($targetFile);
 
@@ -76,7 +76,7 @@ it('can optimize an image using a provided optimizer chain', function () {
     expect($targetFile)->toBeFile();
 });
 
-it('can optimize an image specifying a desired timeout', function () {
+it('can optimize an image specifying a desired timeout with a configuration array key', function () {
     $targetFile = $this->tempDir->path('optimized.jpg');
 
     Image::load(getTestFile('test.jpg'))
@@ -89,6 +89,35 @@ it('can optimize an image specifying a desired timeout', function () {
                 ],
             ],
         ])
+        ->save($targetFile);
+
+    expect($targetFile)->toBeFile();
+});
+
+it('can optimize an image specifying a desired timeout with a method argument', function () {
+    $targetFile = $this->tempDir->path('optimized.jpg');
+
+    Image::load(getTestFile('test.jpg'))
+        ->setOptimizeChain(OptimizerChainFactory::create())
+        ->optimize([
+            'optimizers' => [
+                Jpegoptim::class => [
+                    '--all-progressive',
+                ],
+            ],
+        ], timeout: 120)
+        ->save($targetFile);
+
+    expect($targetFile)->toBeFile();
+});
+
+it('can optimize an image with options format backward compatibility and timeout parameter', function () {
+    $targetFile = $this->tempDir->path('optimized.jpg');
+
+    Image::load(getTestFile('test.jpg'))
+        ->optimize([Jpegoptim::class => [
+            '--all-progressive',
+        ]], timeout: 120)
         ->save($targetFile);
 
     expect($targetFile)->toBeFile();

--- a/tests/Manipulations/OptimizeTest.php
+++ b/tests/Manipulations/OptimizeTest.php
@@ -32,6 +32,22 @@ it('can optimize an image with the given optimization options', function () {
     $targetFile = $this->tempDir->path('optimized.jpg');
 
     Image::load(getTestFile('test.jpg'))
+        ->optimize([
+            'optimizers' => [
+                Jpegoptim::class => [
+                    '--all-progressive',
+                ],
+            ],
+        ])
+        ->save($targetFile);
+
+    expect($targetFile)->toBeFile();
+});
+
+it('can optimize an image with options format backward compatibility', function () {
+    $targetFile = $this->tempDir->path('optimized.jpg');
+
+    Image::load(getTestFile('test.jpg'))
         ->optimize([Jpegoptim::class => [
         '--all-progressive',
         ]])
@@ -46,12 +62,14 @@ it('can optimize an image using a provided optimizer chain', function () {
     Image::load(getTestFile('test.jpg'))
         ->setOptimizeChain(OptimizerChainFactory::create())
         ->optimize([
-        Pngquant::class => [
-            '--force',
-        ],
-        Jpegoptim::class => [
-            '--all-progressive',
-        ],
+            'optimizers' => [
+                Pngquant::class => [
+                    '--force',
+                ],
+                Jpegoptim::class => [
+                    '--all-progressive',
+                ],
+            ],
         ])
         ->save($targetFile);
 

--- a/tests/Manipulations/OptimizeTest.php
+++ b/tests/Manipulations/OptimizeTest.php
@@ -57,3 +57,21 @@ it('can optimize an image using a provided optimizer chain', function () {
 
     expect($targetFile)->toBeFile();
 });
+
+it('can optimize an image specifying a desired timeout', function () {
+    $targetFile = $this->tempDir->path('optimized.jpg');
+
+    Image::load(getTestFile('test.jpg'))
+        ->setOptimizeChain(OptimizerChainFactory::create())
+        ->optimize([
+            'timeout' => 120,
+            'optimizers' => [
+                Jpegoptim::class => [
+                    '--all-progressive',
+                ],
+            ],
+        ])
+        ->save($targetFile);
+
+    expect($targetFile)->toBeFile();
+});


### PR DESCRIPTION
This PR introduces an ability to set `timeout` for the `OptimizerChain` other than the default 60s when calling the `optimize` method.

The `optimize` manipulation configuration under the hood is being stored as a JSON string at runtime. And it is being `json_encode`/`json_decode`'d each time when we are configuring the optimizer or running the optimizations. This design decision was a limiting factor to find a proper solution. So, IMO, the only way to achieve the goal of this PR was to play around with the configuration array structure as no PHP OOP can be used to pass the optimizers' configuration.

**Rationale**

I've ran into an issue while running optimizer for a 2600px retina (2x) WebP images. From time to time such images are hitting the default 60s timeout.

Here is a sample of an error message thrown via the `Symfony\Component\Process\Exception\ProcessTimedOutException`:
```
The process \"\"cwebp\" -q 85 -m 6 -pass 10 -mt '/var/www/storage/media-library/temp/JWrithAGLF2WKk74bEtaNtPXtlh9sSVg/wxsCJGDr2AQeM7WnSoGlugLiVa7hSHB02600px-2x-webp.JPG' -o '/var/www/storage/media-library/temp/JWrithAGLF2WKk74bEtaNtPXtlh9sSVg/wxsCJGDr2AQeM7WnSoGlugLiVa7hSHB02600px-2x-webp.JPG'\" exceeded the timeout of 60 seconds.
```

Under the hood in the `Spatie\ImageOptimizer\OptimizerChain` there’s a property `protected $timeout = 60;` with a public setter, see:
- https://github.com/spatie/image-optimizer/blob/d962af4663e18613e828c611193b8aa8fddba9a4/src/OptimizerChain.php#L16-L17
- https://github.com/spatie/image-optimizer/blob/d962af4663e18613e828c611193b8aa8fddba9a4/src/OptimizerChain.php#L47-L55.

But higher in the call stack the property is not being used at all and `OptimizerChain` instances are always running with the default timeout value of 60 s, see https://github.com/spatie/image/blob/cb1bb1ad45e2ae76836e27fe0822c1ea8f0f8b2c/src/Image.php#L138-L159.

So it was required to introduce an ability to set the timeout.