### PR TITLE
Fit with only width or height

### DIFF
--- a/src/Manipulations.php
+++ b/src/Manipulations.php
@@ -193,7 +193,7 @@ class Manipulations
     /**
      * @throws InvalidManipulation
      */
-    public function fit(string $fitMethod, int $width, int $height): static
+    public function fit(string $fitMethod, ?int $width = null, ?int $height = null): static
     {
         if (! $this->validateManipulation($fitMethod, 'fit')) {
             throw InvalidManipulation::invalidParameter(
@@ -203,8 +203,17 @@ class Manipulations
             );
         }
 
-        $this->width($width);
-        $this->height($height);
+        if ($width === null && $height === null) {
+            throw new InvalidManipulation('Width or height or both must be provided');
+        }
+
+        if ($width !== null) {
+            $this->width($width);
+        }
+
+        if ($height !== null) {
+            $this->height($height);
+        }
 
         return $this->addManipulation('fit', $fitMethod);
     }

--- a/tests/Manipulations/FitTest.php
+++ b/tests/Manipulations/FitTest.php
@@ -14,6 +14,31 @@ it('can fit an image', function () {
     expect($targetFile)->toBeFile();
 });
 
+it('can fit an image with only width', function () {
+    $targetFile = $this->tempDir->path('conversion.jpg');
+
+    Image::load(getTestJpg())->fit(Manipulations::FIT_FILL_MAX, width: 500)->save($targetFile);
+
+    expect($targetFile)->toBeFile();
+    expect(getimagesize($targetFile)[0])->toBe(500);
+    expect(getimagesize($targetFile)[1])->toBe(412);
+});
+
+
+it('can fit an image with only height', function () {
+    $targetFile = $this->tempDir->path('conversion.jpg');
+
+    Image::load(getTestJpg())->fit(Manipulations::FIT_FILL_MAX, height: 500)->save($targetFile);
+
+    expect($targetFile)->toBeFile();
+    expect(getimagesize($targetFile)[0])->toBe(607);
+    expect(getimagesize($targetFile)[1])->toBe(500);
+});
+
 it('will throw an exception when passing an invalid fit', function () {
     Image::load(getTestJpg())->fit('blabla', 500, 300);
+})->throws(InvalidManipulation::class);
+
+it('will throw an exception when passing no width and no height', function () {
+    Image::load(getTestJpg())->fit(Manipulations::FIT_CONTAIN);
 })->throws(InvalidManipulation::class);


### PR DESCRIPTION
Currently the `fit()` manipulation requires you to specify both a width and a height. But in my projects, I only want to fit the image within a specific width. The height does not matter. This PR makes it possible to use the `fit()` with only a height or width by using named arguments.
```php
$image->fit(Manipulations::FIT_MAX, width: 500);
$image->fit(Manipulations::FIT_MAX, height: 500);
```