### PR TITLE
Apply json_decode have JSON_THROW_ON_ERROR

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -124,7 +124,7 @@ class Image
         if ($this->shouldOptimize()) {
             $optimizerChainConfiguration = $this->manipulations->getFirstManipulationArgument('optimize');
 
-            $optimizerChainConfiguration = json_decode($optimizerChainConfiguration, true);
+            $optimizerChainConfiguration = json_decode($optimizerChainConfiguration, true, 512, JSON_THROW_ON_ERROR);
 
             $this->performOptimization($outputPath, $optimizerChainConfiguration);
         }


### PR DESCRIPTION
# Changed log

- According to the [reference](https://wiki.php.net/rfc/json_throw_on_error), it should be great for throwing the error when calling the `json_decode` function has been problematic.