### PR TITLE
Add `OptimizerChain::setTimeout()` to the image optimization tests and docs

### DIFF
--- a/docs/image-manipulations/optimizing-images.md
+++ b/docs/image-manipulations/optimizing-images.md
@@ -5,7 +5,7 @@ weight: 3
 
 ## Requirements
 
-Optimization of images is done by the underlying [spatie/image-optimizer](https://github.com/spatie/image-optimizer). It assumes that there are a few optimization tools, such as [JpegOptim](http://freecode.com/projects/jpegoptim) an [Pngquant](https://pngquant.org/) present on your system. For more info, check out [the relevant docs](https://github.com/spatie/image-optimizer#optimization-tools).
+Optimization of images is done by the underlying [spatie/image-optimizer](https://github.com/spatie/image-optimizer) package. It assumes that there are a few optimization tools, such as [JpegOptim](http://freecode.com/projects/jpegoptim) an [Pngquant](https://pngquant.org/) present on your system. For more info, check out [the relevant docs](https://github.com/spatie/image-optimizer#optimization-tools).
 
 ## How to use
 
@@ -28,15 +28,18 @@ No matter where or how many times you call `optimize` in you chain, it will alwa
 
 ## Customizing the optimization
 
-To optimization of images is done by the underlying [spatie/image-optimizer](https://github.com/spatie/image-optimizer) package. You can customize this by passing a [OptimizerChain](https://github.com/spatie/image-optimizer#creating-your-own-optimization-chains) instance. 
+You can customize the optimization by passing an [`OptimizerChain`](https://github.com/spatie/image-optimizer#creating-your-own-optimization-chains) instance to the `optimize` method.
+
+For the `OptimizerChain` instance you can also set the maximum of time in seconds that each individual optimizer in a chain can use by calling `setTimeout`. The default value is 60 seconds. Adjusting this setting may be inevitable while working with large images (see e.g. [#187](https://github.com/spatie/image/pull/187)).
 
 ```php
 $optimizerChain = (new OptimizerChain)
-        ->addOptimizer(new Jpegoptim([
-            '--strip-all',
-            '--all-progressive',
-            '-m85'
-        ]));
+    ->addOptimizer(new Jpegoptim([
+        '--strip-all',
+        '--all-progressive',
+        '-m85'
+    ]))
+    ->setTimeout(90);
 
 Image::load('example.jpg')
     ->optimize($optimizerChain)

--- a/tests/Manipulations/OptimizeTest.php
+++ b/tests/Manipulations/OptimizeTest.php
@@ -15,7 +15,8 @@ it('can optimize an image', function (ImageDriver $driver) {
             '--strip-all',
             '--all-progressive',
             '-m85',
-        ]));
+        ]))
+        ->setTimeout(90);
 
     $driver->loadFile($testFile)->optimize($optimizerChain)->save($optimizedFile);
     $driver->loadFile($testFile)->save($controlFile);


### PR DESCRIPTION
This PR adds documentation on how to set the timeout for image optimizations other than the default 60 seconds.

It was previously implemented in the https://github.com/spatie/image/pull/187, but after the new major v3 release the way we can configure image optimizations changed.