### PR TITLE
Image load fix

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -28,6 +28,10 @@ class Image implements ImageDriver
     public function __construct(protected ?string $pathToImage = null)
     {
         $this->imageDriver = new ImagickDriver();
+
+        if ($this->pathToImage) {
+            $this->imageDriver->loadFile($this->pathToImage);
+        }
     }
 
     public static function load(string $pathToImage): static

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -23,6 +23,12 @@ it('will use imagick if it is available', function () {
     expect($image->driverName())->toEqual('imagick');
 });
 
+it('it can load image from file', function () {
+    $image = Image::load(getTestJpg());
+
+    expect($image->getHeight())->toEqual(280);
+});
+
 it('will throw an exception when no file exists at the given path', function () {
     $invalidPath = getTestJpg().'non-existing';
 


### PR DESCRIPTION
Reference: https://twitter.com/freekmurze/status/1736801633986916639

When passing an image filename to `Image::__construct()` and `Image::load()`, the file wasn't actually being loaded by the driver. The only way for it to work would be `(new Image())->loadFile('file/path')`.