### PR TITLE
Edit GdDriver to not throw exception for svg format

### DIFF
--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -149,6 +149,8 @@ class GdDriver implements ImageDriver
             case 'avif':
                 imageavif($this->image, $path);
                 break;
+            case 'svg';
+                break;
             default:
                 throw UnsupportedImageFormat::make($extension);
         }
@@ -679,6 +681,7 @@ class GdDriver implements ImageDriver
 
         switch (strtolower($format)) {
             case 'jpg':
+            case 'svg':
             case 'jpeg':
                 imagejpeg($this->image, null, $this->quality);
                 break;

--- a/tests/ImageFormatTest.php
+++ b/tests/ImageFormatTest.php
@@ -26,7 +26,7 @@ it('can save supported formats using format() function', function (ImageDriver $
         return;
     }
     $driver->loadFile(getTestJpg())->format($format);
-})->with('drivers', ['jpeg', 'gif', 'png', 'webp', 'avif'])->throwsNoExceptions();
+})->with('drivers', ['jpeg', 'gif', 'png', 'webp', 'avif', 'svg'])->throwsNoExceptions();
 
 it('can save tiff', function () {
     $format = 'tiff';
@@ -49,6 +49,15 @@ it('can save heic', function () {
 
     expect($targetFile)->toHaveMime("image/$format");
 })->skipIfImagickDoesNotSupportFormat('heic');
+
+it('can save svg', function () {
+    $format = 'svg';
+    $driver = Image::useImageDriver('gd');
+
+    $targetFile = $this->tempDir->path("{$driver->driverName()}/format-test.$format");
+
+    $driver->loadFile(getTestJpg())->save($targetFile);
+})->throwsNoExceptions();
 
 it('throws an error for unsupported GD image formats', function (string $format) {
     $driver = Image::useImageDriver('gd');


### PR DESCRIPTION
In the previous versions (while using spatie/laravel-medialibrary) trying to make conversions of svg's would create a jpg conversions.
In the latest version (11.x.x), which uses spatie/image v3, this throws an 'UnsupportedImageFormat' exception.

This PR tries to fix this by just adding 'svg' to the switch statement and instead of throwing an exception just doing nothing. This will result in a jpg conversion when using spatie/laravel-medialibrary.

This is my first attempt at a PR for this repo so please let me know if I've overlooked something!