### PR TITLE
Fix enum case

### DIFF
--- a/docs/usage/basic-usage.md
+++ b/docs/usage/basic-usage.md
@@ -16,7 +16,7 @@ $image = Image::load(string $pathToImage);
 By default, the Imagick driver will be used. However if you would like to use GD you can do this by selecting the driver before loading the image.
 
 ```php
-$image = Image::useImageDriver(ImageDriver::GD)->load(string $pathToImage);
+$image = Image::useImageDriver(ImageDriver::Gd)->load(string $pathToImage);
 ```
 
 ## Applying manipulations


### PR DESCRIPTION
The `ImageDriver` enum has `Gd` as case instead of `GD`.