### PR TITLE
update load image with gd driver example

### DIFF
--- a/docs/usage/basic-usage.md
+++ b/docs/usage/basic-usage.md
@@ -16,7 +16,7 @@ $image = Image::load(string $pathToImage);
 By default, the Imagick driver will be used. However if you would like to use GD you can do this by selecting the driver before loading the image.
 
 ```php
-$image = Image::useImageDriver(ImageDriver::Gd)->load(string $pathToImage);
+$image = Image::useImageDriver(ImageDriver::Gd)->loadFile(string $pathToImage);
 ```
 
 ## Applying manipulations


### PR DESCRIPTION
The `load` method creates a new class from `static` and ignores the changed image drive. I guess in this example, the `loadFile` method should be used.