### PR TITLE
[fix] Allow constant IMG_WEBP_LOSSLESS in quality

### DIFF
--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -159,7 +159,8 @@ class GdDriver implements ImageDriver
                 imagegif($this->image, $path);
                 break;
             case 'webp':
-                imagewebp($this->image, $path, $this->quality);
+                $quality = $this->quality === 100 ? IMG_WEBP_LOSSLESS : $this->quality;
+                imagewebp($this->image, $path, $quality);
                 break;
             case 'avif':
                 imageavif($this->image, $path, $this->quality);

--- a/src/Image.php
+++ b/src/Image.php
@@ -305,7 +305,7 @@ class Image implements ImageDriver
 
     public function quality(int $quality): static
     {
-        $this->ensureNumberBetween($quality, 0, IMG_WEBP_LOSSLESS, 'quality');
+        $this->ensureNumberBetween($quality, 0, 100, 'quality');
 
         $this->imageDriver->quality($quality);
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -305,7 +305,7 @@ class Image implements ImageDriver
 
     public function quality(int $quality): static
     {
-        $this->ensureNumberBetween($quality, 0, 100, 'quality');
+        $this->ensureNumberBetween($quality, 0, IMG_WEBP_LOSSLESS, 'quality');
 
         $this->imageDriver->quality($quality);
 


### PR DESCRIPTION
in PHP8.1 a new [IMG_WEBP_LOSSLESS](https://www.php.net/manual/en/image.constants.php#constant.img-webp-lossless) constant has been added to allow lossless conversion for webp

this PR will extend the quality allowed range from 0-100 to 0-101 (IMG_WEBP_LOSSLESS value)