### PR TITLE
Suppress warnings from imagecreatefromstring

### DIFF
--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -86,7 +86,7 @@ class GdDriver implements ImageDriver
 
         $this->setExif($path);
 
-        $image = imagecreatefromstring($contents);
+        $image = @imagecreatefromstring($contents);
 
         if (! $image) {
             throw CouldNotLoadImage::make($path);


### PR DESCRIPTION
`imagecreatefromstring` handles warnings as errors, and throws exceptions that wouldn't impact image manipulation.

For example:
`ErrorException: imagecreatefromstring(): gd-png: libpng warning: iCCP: known incorrect sRGB profile`

This is a warning, and image manipulations work fine when the warning is ignored.

This pull request suppresses those warnings so they don't cause manipulations to fail unnecessarily.