### PR TITLE
Suppress warnings from exif_read_data

### DIFF
--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -554,7 +554,7 @@ class GdDriver implements ImageDriver
             return;
         }
 
-        $result = exif_read_data($path);
+        $result = @exif_read_data($path);
 
         if (! is_array($result)) {
             $this->exif = [];


### PR DESCRIPTION
In a similar vein to #243, this update silences exif data warnings. 

When importing thousands of images, a small percentage created exif warnings and therefore were unable to be processed, leaving gaps in our catalog data.

I would presume the majority would prefer image conversions to continue, rather than error.