### PR TITLE
Fix saving jfif image

### DIFF
--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -151,6 +151,7 @@ class GdDriver implements ImageDriver
         switch (strtolower($extension)) {
             case 'jpg':
             case 'jpeg':
+            case 'jfif':
                 imagejpeg($this->image, $path, $this->quality);
                 break;
             case 'png':
@@ -185,6 +186,7 @@ class GdDriver implements ImageDriver
         switch (strtolower($imageFormat)) {
             case 'jpg':
             case 'jpeg':
+            case 'jfif':
                 imagejpeg($this->image, null, $this->quality);
                 break;
             case 'png':

--- a/src/Drivers/Imagick/ImagickDriver.php
+++ b/src/Drivers/Imagick/ImagickDriver.php
@@ -237,7 +237,13 @@ class ImagickDriver implements ImageDriver
 
         $extension = pathinfo($path, PATHINFO_EXTENSION);
 
-        if (! in_array(strtoupper($extension), Imagick::queryFormats('*'))) {
+        $formats = Imagick::queryFormats('*');
+
+        if (in_array('JPEG', $formats)) {
+            $formats[] = 'JFIF';
+        }
+
+        if (! in_array(strtoupper($extension), $formats)) {
             throw UnsupportedImageFormat::make($extension);
         }
 

--- a/tests/ImageFormatTest.php
+++ b/tests/ImageFormatTest.php
@@ -16,8 +16,14 @@ it('can save supported formats', function (ImageDriver $driver, string $format) 
 
     $driver->loadFile(getTestJpg())->save($targetFile);
 
-    expect($targetFile)->toHaveMime("image/$format");
-})->with('drivers', ['jpeg', 'gif', 'png', 'webp', 'avif']);
+    $expectedFormat = $format;
+
+    if (in_array($expectedFormat, ['jpg', 'jfif'])) {
+        $expectedFormat = 'jpeg';
+    }
+
+    expect($targetFile)->toHaveMime("image/$expectedFormat");
+})->with('drivers', ['jpeg', 'jpg', 'jfif', 'gif', 'png', 'webp', 'avif']);
 
 it('can save supported formats using format() function', function (ImageDriver $driver, string $format) {
     if ($format === 'avif' && ! avifIsSupported($driver->driverName())) {


### PR DESCRIPTION
Saving a jfif image (jpeg) creates the "Spatie\Image\Exceptions\UnsupportedImageFormat" exception.
This PR fixes it.

