### PR TITLE
Ability to resize canvas when keeping fill background a certain color

### DIFF
--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -525,13 +525,7 @@ class GdDriver implements ImageDriver
 
     public function overlay(ImageDriver $bottomImage, ImageDriver $topImage, int $x = 0, int $y = 0): static
     {
-        $bottomImage->save(base_path('_bottom.png'));
-        $topImage->save(base_path('_top.png'));
-
         $bottomImage->insert($topImage, AlignPosition::TopLeft, $x, $y);
-
-        $bottomImage->save(base_path('_z.png'));
-
         $this->image = $bottomImage->image();
 
         return $this;

--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -225,7 +225,13 @@ class GdDriver implements ImageDriver
         return new Size($this->getWidth(), $this->getHeight());
     }
 
-    public function fit(Fit $fit, ?int $desiredWidth = null, ?int $desiredHeight = null): static
+    public function fit(
+        Fit $fit,
+        ?int $desiredWidth = null,
+        ?int $desiredHeight = null,
+        bool $relative = false,
+        string $backgroundColor = '#ffffff'
+    ): static
     {
         if ($fit === Fit::Crop) {
             return $this->fitCrop($fit, $this->getWidth(), $this->getHeight(), $desiredWidth, $desiredHeight);
@@ -248,7 +254,7 @@ class GdDriver implements ImageDriver
         );
 
         if ($fit->shouldResizeCanvas()) {
-            $this->resizeCanvas($desiredWidth, $desiredHeight, AlignPosition::Center);
+            $this->resizeCanvas($desiredWidth, $desiredHeight, AlignPosition::Center, $relative, $backgroundColor);
         }
 
         return $this;
@@ -519,7 +525,13 @@ class GdDriver implements ImageDriver
 
     public function overlay(ImageDriver $bottomImage, ImageDriver $topImage, int $x = 0, int $y = 0): static
     {
+        $bottomImage->save(base_path('_bottom.png'));
+        $topImage->save(base_path('_top.png'));
+
         $bottomImage->insert($topImage, AlignPosition::TopLeft, $x, $y);
+
+        $bottomImage->save(base_path('_z.png'));
+
         $this->image = $bottomImage->image();
 
         return $this;

--- a/src/Drivers/ImageDriver.php
+++ b/src/Drivers/ImageDriver.php
@@ -52,7 +52,13 @@ interface ImageDriver
 
     public function getSize(): Size;
 
-    public function fit(Fit $fit, ?int $desiredWidth = null, ?int $desiredHeight = null): static;
+    public function fit(
+        Fit $fit, 
+        ?int $desiredWidth = null, 
+        ?int $desiredHeight = null,
+        bool $relative = false,
+        string $backgroundColor = '#ffffff'
+    ): static;
 
     public function pickColor(int $x, int $y, ColorFormat $colorFormat): mixed;
 

--- a/src/Drivers/Imagick/ImagickDriver.php
+++ b/src/Drivers/Imagick/ImagickDriver.php
@@ -119,13 +119,13 @@ class ImagickDriver implements ImageDriver
 
         return $this;
     }
-    
+
     public function fit(
         Fit $fit, 
         ?int $desiredWidth = null, 
         ?int $desiredHeight = null,
         bool $relative = false,
-        string $backgroundColor = '#ffffff'
+        string $backgroundColor = null,
     ): static
     {
         if ($fit === Fit::Crop) {

--- a/src/Drivers/Imagick/ImagickDriver.php
+++ b/src/Drivers/Imagick/ImagickDriver.php
@@ -144,7 +144,7 @@ class ImagickDriver implements ImageDriver
         }
 
         if ($fit->shouldResizeCanvas()) {
-            $this->resizeCanvas($desiredWidth, $desiredHeight, AlignPosition::Center, false, null);
+            $this->resizeCanvas($desiredWidth, $desiredHeight, AlignPosition::Center, $relative, $backgroundColor);
         }
 
         return $this;

--- a/src/Drivers/Imagick/ImagickDriver.php
+++ b/src/Drivers/Imagick/ImagickDriver.php
@@ -119,8 +119,14 @@ class ImagickDriver implements ImageDriver
 
         return $this;
     }
-
-    public function fit(Fit $fit, ?int $desiredWidth = null, ?int $desiredHeight = null): static
+    
+    public function fit(
+        Fit $fit, 
+        ?int $desiredWidth = null, 
+        ?int $desiredHeight = null,
+        bool $relative = false,
+        string $backgroundColor = '#ffffff'
+    ): static
     {
         if ($fit === Fit::Crop) {
             return $this->fitCrop($fit, $this->getWidth(), $this->getHeight(), $desiredWidth, $desiredHeight);

--- a/src/Image.php
+++ b/src/Image.php
@@ -173,9 +173,15 @@ class Image implements ImageDriver
         return $this->imageDriver->getSize();
     }
 
-    public function fit(Fit $fit, ?int $desiredWidth = null, ?int $desiredHeight = null): static
+    public function fit(
+        Fit $fit,
+        ?int $desiredWidth = null,
+        ?int $desiredHeight = null,
+        bool $relative = false,
+        string $backgroundColor = '#ffffff'
+    ): static
     {
-        $this->imageDriver->fit($fit, $desiredWidth, $desiredHeight);
+        $this->imageDriver->fit($fit, $desiredWidth, $desiredHeight, $relative, $backgroundColor);
 
         return $this;
     }


### PR DESCRIPTION
Before:

```php
    public function registerMediaConversions(BaseMedia $media = null): void
    {
        $this->addMediaConversion('avatar-minified')
            // It's not possible to define a background color.
            ->fit(Fit::Fill, 320, 320)
            ->performOnCollections('avatar');
    }
```

```php
    public function registerMediaConversions(BaseMedia $media = null): void
    {
        $this->addMediaConversion('avatar-minified')
            // We can now specify the background color we want
            ->fit(Fit::Fill, 320, 320, false, $media?->custom_properties['background'] ?? '000000')
            ->performOnCollections('avatar');
    }
```

Before:
![image](https://github.com/spatie/image/assets/8682003/47d40357-e484-4749-919f-1aa23101d5f6)


After:
![image](https://github.com/spatie/image/assets/8682003/3c6574da-b89c-4c37-bd64-10eac7dccc26)
