### PR TITLE
Update ImagickDriver.php to get V10 blur style

### DIFF
--- a/src/Drivers/Imagick/ImagickDriver.php
+++ b/src/Drivers/Imagick/ImagickDriver.php
@@ -115,7 +115,7 @@ class ImagickDriver implements ImageDriver
     public function blur(int $blur): static
     {
         foreach ($this->image as $image) {
-            $image->blurImage(0.5 * $blur, 0.1 * $blur);
+            $image->blurImage(1 * $blur, 0.5 * $blur);
         }
 
         return $this;


### PR DESCRIPTION
The V11 result / method differs mayor from the V10 blur result. Also with blur(100) the result is very "unblurry". These constants are fromt he old Intervention BlurCommand. So there is the same result as V10.