### PR TITLE
fix: GdDriver resizeCanvas save alpha channel;

### DIFF
--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -394,6 +394,7 @@ class GdDriver implements ImageDriver
         // even if background-color is set
         $transparent = imagecolorallocatealpha($canvas->image, 255, 255, 255, 127);
         imagealphablending($canvas->image, false); // do not blend / just overwrite
+        imagesavealpha($canvas->image, true); // save alpha channel
         imagefilledrectangle($canvas->image, $destinationX, $destinationY, $destinationX + $sourceWidth - 1, $destinationY + $sourceHeight - 1, $transparent);
 
         // copy image into new canvas

--- a/tests/Manipulations/ResizeTest.php
+++ b/tests/Manipulations/ResizeTest.php
@@ -16,17 +16,22 @@ it('can resize an image', function (ImageDriver $driver) {
     assertMatchesImageSnapshot($targetFile);
 })->with('drivers');
 
-it('can resize canvas of transparent pngs without loosing transparency when GD is used', function () {
-    $image = Image::useImageDriver(ImageDriver::Gd)->loadFile(getTestFile('transparent.png')); // 1640x923
+it('can resize canvas of transparent PNGs without loosing transparency when GD is used', function (ImageDriver $driver) {
+    if ($driver->driverName() !== 'gd') {
+        return $this->expectNotToPerformAssertions();
+    }
+
     $targetFile = $this->tempDir->path("{$driver->driverName()}/resize-with-transparent-png.png");
-    $transparent = imagecolorallocatealpha($canvas->image, 255, 255, 255, 127);
+    $image = $driver->loadFile(getTestFile('transparent.png')); // 1640x923
+    $transparentColor = imagecolorallocatealpha($image->image(), 255, 255, 255, 127);
+
     expect($image->getHeight())->toEqual(923);
-    expect($image->pickColor(0, 0, \Spatie\Image\Enums\ColorFormat::Int))->toEqual($transparent);
+    expect($image->pickColor(0, 0, \Spatie\Image\Enums\ColorFormat::Int))->toEqual($transparentColor);
 
     // make it square, so height is added top and bottom, bg transparent
     $image->resizeCanvas(1640, 1640, \Spatie\Image\Enums\AlignPosition::Center, false, $image->pickColor(0, 0, \Spatie\Image\Enums\ColorFormat::Rgba))->save($targetFile);
 
     $targetImage = $driver->loadFile($targetFile);
     expect($targetImage->getHeight())->toEqual(1640);
-    expect($targetImage->pickColor(0, 0, \Spatie\Image\Enums\ColorFormat::Int))->toEqual($transparent);
-});
+    expect($targetImage->pickColor(0, 0, \Spatie\Image\Enums\ColorFormat::Int))->toEqual($transparentColor);
+})->with('drivers');

--- a/tests/Manipulations/ResizeTest.php
+++ b/tests/Manipulations/ResizeTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\Image\Drivers\ImageDriver;
+use Spatie\Image\Image;
 
 use function Spatie\Snapshots\assertMatchesImageSnapshot;
 
@@ -14,3 +15,18 @@ it('can resize an image', function (ImageDriver $driver) {
 
     assertMatchesImageSnapshot($targetFile);
 })->with('drivers');
+
+it('can resize canvas of transparent pngs without loosing transparency when GD is used', function () {
+    $image = Image::useImageDriver(ImageDriver::Gd)->loadFile(getTestFile('transparent.png')); // 1640x923
+    $targetFile = $this->tempDir->path("{$driver->driverName()}/resize-with-transparent-png.png");
+    $transparent = imagecolorallocatealpha($canvas->image, 255, 255, 255, 127);
+    expect($image->getHeight())->toEqual(923);
+    expect($image->pickColor(0, 0, \Spatie\Image\Enums\ColorFormat::Int))->toEqual($transparent);
+
+    // make it square, so height is added top and bottom, bg transparent
+    $image->resizeCanvas(1640, 1640, \Spatie\Image\Enums\AlignPosition::Center, false, $image->pickColor(0, 0, \Spatie\Image\Enums\ColorFormat::Rgba))->save($targetFile);
+
+    $targetImage = $driver->loadFile($targetFile);
+    expect($targetImage->getHeight())->toEqual(1640);
+    expect($targetImage->pickColor(0, 0, \Spatie\Image\Enums\ColorFormat::Int))->toEqual($transparent);
+});

--- a/tests/Manipulations/ResizeTest.php
+++ b/tests/Manipulations/ResizeTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Spatie\Image\Drivers\ImageDriver;
-use Spatie\Image\Image;
 
 use function Spatie\Snapshots\assertMatchesImageSnapshot;
 


### PR DESCRIPTION
Should resolve [this issue](https://github.com/spatie/laravel-medialibrary/issues/3502) with GdDriver `fit` and `resizeCanvas`. 