### PR TITLE
Fix bug in ImagickDriver::pixelate, Update tests

### DIFF
--- a/src/Drivers/Imagick/ImagickDriver.php
+++ b/src/Drivers/Imagick/ImagickDriver.php
@@ -470,6 +470,10 @@ class ImagickDriver implements ImageDriver
 
     public function pixelate(int $pixelate = 50): static
     {
+        if ($pixelate === 0) {
+            return $this;
+        }
+
         $width = $this->getWidth();
         $height = $this->getHeight();
 

--- a/tests/Manipulations/BlurTest.php
+++ b/tests/Manipulations/BlurTest.php
@@ -5,13 +5,13 @@ use Spatie\Image\Exceptions\InvalidManipulation;
 
 use function Spatie\Snapshots\assertMatchesImageSnapshot;
 
-it('can blur an image', function (ImageDriver $driver) {
+it('can blur an image', function (ImageDriver $driver, int $blur) {
     $targetFile = $this->tempDir->path("{$driver->driverName()}/blur.png");
 
-    $driver->loadFile(getTestJpg())->blur(50)->save($targetFile);
+    $driver->loadFile(getTestJpg())->blur($blur)->save($targetFile);
 
     assertMatchesImageSnapshot($targetFile);
-})->with('drivers');
+})->with('drivers', [0, 50, 100]);
 
 it('will throw an exception when passing an invalid blur value', function (ImageDriver $driver) {
     $driver->loadFile(getTestJpg())->blur(101);

--- a/tests/Manipulations/PixelateTest.php
+++ b/tests/Manipulations/PixelateTest.php
@@ -1,13 +1,18 @@
 <?php
 
 use Spatie\Image\Drivers\ImageDriver;
+use Spatie\Image\Exceptions\InvalidManipulation;
 
 use function Spatie\Snapshots\assertMatchesImageSnapshot;
 
-it('can pixelate an image', function (ImageDriver $driver) {
+it('can pixelate an image', function (ImageDriver $driver, int $pixelate) {
     $targetFile = $this->tempDir->path("{$driver->driverName()}/pixelate.png");
 
-    $driver->loadFile(getTestJpg())->pixelate()->save($targetFile);
+    $driver->loadFile(getTestJpg())->pixelate($pixelate)->save($targetFile);
 
     assertMatchesImageSnapshot($targetFile);
-})->with('drivers');
+})->with('drivers', [0, 50, 100]);
+
+it('will throw an exception when passing an invalid pixelate value', function (ImageDriver $driver) {
+    $driver->loadFile(getTestJpg())->pixelate(101);
+})->with('drivers')->throws(InvalidManipulation::class);

--- a/tests/Manipulations/SharpenTest.php
+++ b/tests/Manipulations/SharpenTest.php
@@ -5,13 +5,13 @@ use Spatie\Image\Exceptions\InvalidManipulation;
 
 use function Spatie\Snapshots\assertMatchesImageSnapshot;
 
-it('can sharpen an image', function (ImageDriver $driver) {
+it('can sharpen an image', function (ImageDriver $driver, int $sharpen) {
     $targetFile = $this->tempDir->path("{$driver->driverName()}/sharpen.png");
 
-    $driver->loadFile(getTestJpg())->sharpen(50)->save($targetFile);
+    $driver->loadFile(getTestJpg())->sharpen($sharpen)->save($targetFile);
 
     assertMatchesImageSnapshot($targetFile);
-})->with('drivers');
+})->with('drivers', [0, 50, 100]);
 
 it('will throw an exception when passing an invalid sharpen value', function (ImageDriver $driver) {
     $driver->loadFile(getTestJpg())->sharpen(101);


### PR DESCRIPTION
Because pull request #262 was a complete mess, here another one.

Fixing a bug in ImagickDriver::pixelate causing a DivisionByZeroError. 
