### PR TITLE
Improve DX by specifying namespace for GD functions

### DIFF
--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -153,20 +153,20 @@ class GdDriver implements ImageDriver
             case 'jpg':
             case 'jpeg':
             case 'jfif':
-                imagejpeg($this->image, $path, $this->quality);
+                \imagejpeg($this->image, $path, $this->quality);
                 break;
             case 'png':
-                imagepng($this->image, $path, $this->pngCompression());
+                \imagepng($this->image, $path, $this->pngCompression());
                 break;
             case 'gif':
-                imagegif($this->image, $path);
+                \imagegif($this->image, $path);
                 break;
             case 'webp':
                 $quality = $this->quality === 100 ? IMG_WEBP_LOSSLESS : $this->quality;
-                imagewebp($this->image, $path, $quality);
+                \imagewebp($this->image, $path, $quality);
                 break;
             case 'avif':
-                imageavif($this->image, $path, $this->quality);
+                \imageavif($this->image, $path, $this->quality);
                 break;
             default:
                 throw UnsupportedImageFormat::make($extension);
@@ -188,19 +188,19 @@ class GdDriver implements ImageDriver
             case 'jpg':
             case 'jpeg':
             case 'jfif':
-                imagejpeg($this->image, null, $this->quality);
+                \imagejpeg($this->image, null, $this->quality);
                 break;
             case 'png':
-                imagepng($this->image, null, $this->pngCompression());
+                \imagepng($this->image, null, $this->pngCompression());
                 break;
             case 'gif':
-                imagegif($this->image, null);
+                \imagegif($this->image, null);
                 break;
             case 'webp':
-                imagewebp($this->image, null);
+                \imagewebp($this->image, null);
                 break;
             case 'avif':
-                imageavif($this->image, null);
+                \imageavif($this->image, null);
                 break;
             default:
                 throw UnsupportedImageFormat::make($imageFormat);


### PR DESCRIPTION
Why: some of these functions are optional and can be not available in the installed PHP. When PHP couldn't find functions in the current and root namespaces, it reports a missing function in the current namespace. As a result, an Error message is misleading.
Example: `Call to undefined function Spatie\Image\Drivers\Gd\imageavif()`

![CleanShot 2024-08-20 at 23 51 39@2x](https://github.com/user-attachments/assets/e22c9e8e-76e2-41c6-8638-f698dbf2c238)


With this small fix, the error message will be:
```
Call to undefined function imageavif()
```