### PR TITLE
Update basic-usage.md

### DIFF
--- a/docs/usage/basic-usage.md
+++ b/docs/usage/basic-usage.md
@@ -8,14 +8,31 @@ weight: 1
 Load an image by calling the static `load` method on the `Image` and passing in the `$pathToImage`.
 
 ```php
+use Spatie\Image\Image;
+
 $image = Image::load(string $pathToImage);
 ```
+
+
+## Selecting a driver
+
+By default, the Imagick driver will be used. However if you would like to use GD you can do this by selecting the driver before loading the image.
+
+```php
+use Spatie\Image\Image;
+
+$image = Image::load($file)->useImageDriver('imagick'); // for imagick
+$image = Image::load($file)->useImageDriver('gd'); // for gd
+```
+
 
 ## Applying manipulations
 
 Any of the [image manipulations](/image/v1/image-manipulations/overview) can be applied to the loaded `Image` by calling the manipulation's method. All image manipulation methods can be chained.
 
 ```php
+use Spatie\Image\Image;
+
 Image::load('example.jpg')
     ->sepia()
     ->blur(50)
@@ -29,6 +46,8 @@ Image::load('example.jpg')
 Calling the `save` method on an `Image` will save the modifications to the original file. You can save your modified image by passing a `$outputPath` to the `save` method.
 
 ```php
+use Spatie\Image\Image;
+
 Image::load('example.jpg')
     ->width(50)
     ->save('modified-example.jpg');


### PR DESCRIPTION
Adds a section "Selecting a driver"


## Selecting a driver

By default, the Imagick driver will be used. However if you would like to use GD you can do this by selecting the driver before loading the image.

```php
use Spatie\Image\Image;

$image = Image::load($file)->useImageDriver('imagick'); // for imagick
$image = Image::load($file)->useImageDriver('gd'); // for gd
```
