### PR TITLE
Do not remove color profiles when resizing canvas.

### DIFF
--- a/src/Drivers/Imagick/ImagickDriver.php
+++ b/src/Drivers/Imagick/ImagickDriver.php
@@ -237,6 +237,9 @@ class ImagickDriver implements ImageDriver
         $canvas->image->drawImage($rect);
         $canvas->image->transparentPaintImage($fill, 0, 0, false);
 
+        foreach ($this->image->getImageProfiles() as $key => $value) {
+            $canvas->image->setImageProfile($key, $value);
+        }
         $canvas->image->setImageColorspace($this->image->getImageColorspace());
 
         // copy image into new canvas


### PR DESCRIPTION
I noticed resizing images using `fit()` will sometimes change the look of the image. But not for all images, and not for every `Fit::` value. The problem seems to be in `resizeCanvas()`: color profiles will not transfer over to the new canvas.

This PR makes sure that the IMagick driver will copy the color profiles to the new instance that is made in `resizeCanvas()`. I have no fix for the GD driver, as [GD currently does not support color profiles](https://github.com/libgd/libgd/issues/136).