### PR TITLE
Add -90 rotation degree

### DIFF
--- a/src/Enums/Orientation.php
+++ b/src/Enums/Orientation.php
@@ -8,6 +8,7 @@ enum Orientation: int
     case Rotate90 = 90;
     case Rotate180 = 180;
     case Rotate270 = 270;
+    case RotateMinus90 = -90;
 
     public function degrees(): int
     {


### PR DESCRIPTION
Hey, I am not so familiar with the package, but when using the orientation chained method, I cannot pass a degree other than 0, 90, 180 and 270 since the argument is type hinted to the enum Spatie\Image\Enums\Oritentation, so I thought adding a new case RotationMinus90 would be a good idea.

`Image::load($media->getPath())->orientation($request->get('direction') === 'left' ? -90 : Orientation::Rotate90)->base64();`