### PR TITLE
Allow custom image drivers

### DIFF
--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -628,7 +628,7 @@ class GdDriver implements ImageDriver
     ): static {
         $this->ensureNumberBetween($alpha, 0, 100, 'alpha');
         if (is_string($otherImage)) {
-            $otherImage = (new self)->loadFile($otherImage);
+            $otherImage = (new static)->loadFile($otherImage);
         }
 
         $imageSize = $this->getSize()->align($position, $x, $y);
@@ -642,7 +642,7 @@ class GdDriver implements ImageDriver
             throw new Exception('Could not create image');
         }
         imagecopy($cut, $this->image, 0, 0, $target->x, $target->y, $otherImageSize->width, $otherImageSize->height);
-        imagecopy($cut, $otherImage->image, 0, 0, 0, 0, $otherImageSize->width, $otherImageSize->height);
+        imagecopy($cut, $otherImage->image(), 0, 0, 0, 0, $otherImageSize->width, $otherImageSize->height);
 
         imagecopymerge(
             $this->image,

--- a/src/Drivers/Imagick/ImagickDriver.php
+++ b/src/Drivers/Imagick/ImagickDriver.php
@@ -55,7 +55,7 @@ class ImagickDriver implements ImageDriver
         $image->setImageType(Imagick::IMGTYPE_UNDEFINED);
         $image->setColorspace(Imagick::COLORSPACE_UNDEFINED);
 
-        return (new self)->setImage($image);
+        return (new static)->setImage($image);
     }
 
     protected function setImage(Imagick $image): static
@@ -512,11 +512,11 @@ class ImagickDriver implements ImageDriver
     ): static {
         $this->ensureNumberBetween($alpha, 0, 100, 'alpha');
         if (is_string($otherImage)) {
-            $otherImage = (new self)->loadFile($otherImage);
+            $otherImage = (new static)->loadFile($otherImage);
         }
 
-        $otherImage->image->setImageOrientation(Imagick::ORIENTATION_UNDEFINED);
-        $otherImage->image->evaluateImage(Imagick::EVALUATE_DIVIDE, (1 / ($alpha / 100)), Imagick::CHANNEL_ALPHA);
+        $otherImage->image()->setImageOrientation(Imagick::ORIENTATION_UNDEFINED);
+        $otherImage->image()->evaluateImage(Imagick::EVALUATE_DIVIDE, (1 / ($alpha / 100)), Imagick::CHANNEL_ALPHA);
 
         $imageSize = $this->getSize()->align($position, $x, $y);
         $watermarkSize = $otherImage->getSize()->align($position);
@@ -524,7 +524,7 @@ class ImagickDriver implements ImageDriver
 
         foreach ($this->image as $image) {
             $image->compositeImage(
-                $otherImage->image,
+                $otherImage->image(),
                 Imagick::COMPOSITE_OVER,
                 $target->x,
                 $target->y

--- a/src/Exceptions/InvalidImageDriver.php
+++ b/src/Exceptions/InvalidImageDriver.php
@@ -8,6 +8,6 @@ class InvalidImageDriver extends Exception
 {
     public static function driver(string $driver): self
     {
-        return new self("Driver must be `gd` or `imagick`. `{$driver}` provided.");
+        return new self("Driver must be `gd`, `imagick`, or an implementation of `Spatie\Image\Drivers\ImageDriver`. `{$driver}` provided.");
     }
 }

--- a/src/Image.php
+++ b/src/Image.php
@@ -53,15 +53,19 @@ class Image implements ImageDriver
 
     public static function useImageDriver(ImageDriverEnum|string $imageDriver): static
     {
-        if (is_string($imageDriver)) {
-            $imageDriver = ImageDriverEnum::tryFrom($imageDriver)
-                ?? throw InvalidImageDriver::driver($imageDriver);
-        }
+        if (is_subclass_of($imageDriver, ImageDriver::class)) {
+            $driver = new $imageDriver;
+        } else {
+            if (is_string($imageDriver)) {
+                $imageDriver = ImageDriverEnum::tryFrom($imageDriver)
+                    ?? throw InvalidImageDriver::driver($imageDriver);
+            }
 
-        $driver = match ($imageDriver) {
-            ImageDriverEnum::Gd => new GdDriver,
-            ImageDriverEnum::Imagick => new ImagickDriver,
-        };
+            $driver = match ($imageDriver) {
+                ImageDriverEnum::Gd => new GdDriver,
+                ImageDriverEnum::Imagick => new ImagickDriver,
+            };
+        }
 
         $image = new static;
         $image->imageDriver = $driver;


### PR DESCRIPTION
This allows the use of custom drivers via `useImageDriver(MyDriver::class)`.

The changes in the GD and Imagick driver classes make them more easily extendable, so custom drivers can be based on them.