### PR TITLE
Focal Crop and Resize

### DIFF
--- a/src/Drivers/Concerns/CalculatesFocalCropAndResizeCoordinates.php
+++ b/src/Drivers/Concerns/CalculatesFocalCropAndResizeCoordinates.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\Image\Drivers\Concerns;
+
+use Spatie\Image\Enums\AlignPosition;
+use Spatie\Image\Enums\Fit;
+use Spatie\Image\Image;
+
+trait CalculatesFocalCropAndResizeCoordinates
+{
+    public function calculateFocalCropAndResizeCoordinates(
+        ?int $desiredWidth,
+        ?int $desiredHeight,
+        ?float $cropCenterX = 50.0,
+        ?float $cropCenterY = 50.0,
+    ): array {
+        $originalWidth = $this->getWidth();
+        $originalHeight = $this->getHeight();
+
+        $targetRatio = $desiredWidth / $desiredHeight;
+        $originalRatio = $originalWidth / $originalHeight;
+
+        if ($originalRatio > $targetRatio) {
+            // Image is wider, crop width
+            $cropHeight = $originalHeight;
+            $cropWidth = (int) round($cropHeight * $targetRatio);
+        } else {
+            // Image is taller, crop height
+            $cropWidth = $originalWidth;
+            $cropHeight = (int) round($cropWidth / $targetRatio);
+        }
+
+        // Focal point in pixels
+        $focalX = $originalWidth * ($cropCenterX / 100);
+        $focalY = $originalHeight * ($cropCenterY / 100);
+
+        // Top-left crop coordinates
+        $cropX = max(0, min((int) ($focalX - $cropWidth / 2), $originalWidth - $cropWidth));
+        $cropY = max(0, min((int) ($focalY - $cropHeight / 2), $originalHeight - $cropHeight));
+
+        return [$cropWidth, $cropHeight, $cropX, $cropY];
+    }
+}

--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -6,6 +6,7 @@ use Exception;
 use GdImage;
 use Spatie\Image\Drivers\Concerns\AddsWatermark;
 use Spatie\Image\Drivers\Concerns\CalculatesCropOffsets;
+use Spatie\Image\Drivers\Concerns\CalculatesFocalCropAndResizeCoordinates;
 use Spatie\Image\Drivers\Concerns\CalculatesFocalCropCoordinates;
 use Spatie\Image\Drivers\Concerns\GetsOrientationFromExif;
 use Spatie\Image\Drivers\Concerns\PerformsFitCrops;
@@ -33,6 +34,7 @@ class GdDriver implements ImageDriver
     use AddsWatermark;
     use CalculatesCropOffsets;
     use CalculatesFocalCropCoordinates;
+    use CalculatesFocalCropAndResizeCoordinates;
     use GetsOrientationFromExif;
     use PerformsFitCrops;
     use PerformsOptimizations;
@@ -494,6 +496,22 @@ class GdDriver implements ImageDriver
         );
 
         $this->manualCrop($width, $height, $cropCenterX, $cropCenterY);
+
+        return $this;
+    }
+
+    public function focalCropAndResize(int $width, int $height, ?int $cropCenterX = null, ?int $cropCenterY = null): static
+    {
+        [$cropWidth, $cropHeight, $cropX, $cropY] = $this->calculateFocalCropAndResizeCoordinates(
+            $width,
+            $height,
+            $cropCenterX,
+            $cropCenterY
+        );
+
+        $this->manualCrop($cropWidth, $cropHeight, $cropX, $cropY)
+            ->width($width)
+            ->height($height);
 
         return $this;
     }

--- a/src/Drivers/ImageDriver.php
+++ b/src/Drivers/ImageDriver.php
@@ -76,6 +76,8 @@ interface ImageDriver
 
     public function focalCrop(int $width, int $height, ?int $cropCenterX = null, ?int $cropCenterY = null): static;
 
+    public function focalCropAndResize(int $width, int $height, ?int $cropCenterX = null, ?int $cropCenterY = null): static;
+
     public function base64(string $imageFormat, bool $prefixWithFormat = true): string;
 
     public function background(string $color): static;

--- a/src/Drivers/Imagick/ImagickDriver.php
+++ b/src/Drivers/Imagick/ImagickDriver.php
@@ -7,6 +7,7 @@ use ImagickDraw;
 use ImagickPixel;
 use Spatie\Image\Drivers\Concerns\AddsWatermark;
 use Spatie\Image\Drivers\Concerns\CalculatesCropOffsets;
+use Spatie\Image\Drivers\Concerns\CalculatesFocalCropAndResizeCoordinates;
 use Spatie\Image\Drivers\Concerns\CalculatesFocalCropCoordinates;
 use Spatie\Image\Drivers\Concerns\GetsOrientationFromExif;
 use Spatie\Image\Drivers\Concerns\PerformsFitCrops;
@@ -32,6 +33,7 @@ class ImagickDriver implements ImageDriver
     use AddsWatermark;
     use CalculatesCropOffsets;
     use CalculatesFocalCropCoordinates;
+    use CalculatesFocalCropAndResizeCoordinates;
     use GetsOrientationFromExif;
     use PerformsFitCrops;
     use PerformsOptimizations;
@@ -404,6 +406,22 @@ class ImagickDriver implements ImageDriver
         );
 
         $this->manualCrop($width, $height, $cropCenterX, $cropCenterY);
+
+        return $this;
+    }
+
+    public function focalCropAndResize(int $width, int $height, ?int $cropCenterX = null, ?int $cropCenterY = null): static
+    {
+        [$cropWidth, $cropHeight, $cropX, $cropY] = $this->calculateFocalCropAndResizeCoordinates(
+            $width,
+            $height,
+            $cropCenterX,
+            $cropCenterY
+        );
+
+        $this->manualCrop($cropWidth, $cropHeight, $cropX, $cropY)
+            ->width($width)
+            ->height($height);
 
         return $this;
     }

--- a/src/Image.php
+++ b/src/Image.php
@@ -224,6 +224,13 @@ class Image implements ImageDriver
         return $this;
     }
 
+    public function focalCropAndResize(int $width, int $height, ?int $cropCenterX = null, ?int $cropCenterY = null): static
+    {
+        $this->imageDriver->focalCropAndResize($width, $height, $cropCenterX, $cropCenterY);
+
+        return $this;
+    }
+
     public function base64(string $imageFormat = 'jpeg', bool $prefixWithFormat = true): string
     {
         return $this->imageDriver->base64($imageFormat, $prefixWithFormat);


### PR DESCRIPTION
This PR introduces a new `focalCropAndResize` method to complement the existing focalCrop functionality. 

# Problem

Since version 3 the result of the focalCrop has changed: https://github.com/spatie/image/discussions/245

Previously `focalCrop` would work similar to say `->fit(fit: Fit::Max, ...)` but centered on the focal point.

Currently `focalCrop` accepts $cropCenterX and $cropCenterY which seems to have changed to pixels instead of percentages.

The [documentation](https://spatie.be/docs/image/v3/image-manipulations/resizing-images#content-focal-crop) for `focalCrop` also appears outdated; still referencing percentages, `zoom`, `$focalX` and `$focalY` (instead of $cropCenterX / $cropCenterY). I can see the upgrade guide references the removal of the `$zoom` parameter.

# Solution

To solve this problem I've created a new method `focalCropAndResize` and intended to match the behaviour in v2. 

Unlike `focalCrop` it:
- Uses percentages to describe focal point
- First crops the entire photo using the intended aspect ratio similar to Fit:Max, and using the provided focal point as an anchor.
- It will then resize the image to the intended width / height.

This is useful when you want to preserve the full context of an image while still enforcing a specific aspect ratio around a focal point.

# Comparison

<table><tr><td>

Original
Focal point @ 0:0
Size: 1600x1600

</td><td>

![Screenshot 2025-06-24 at 3 49 29 pm](https://github.com/user-attachments/assets/b82f2337-f1d0-4226-9a25-9108c96c24bd)

</td></tr><tr><td>

`focalCrop`

![Screenshot 2025-06-24 at 3 52 20 pm](https://github.com/user-attachments/assets/e5b02ce4-9a69-486f-bae6-32b593719ca8)

</td><td>

![Screenshot 2025-06-24 at 3 51 02 pm](https://github.com/user-attachments/assets/ec4569fa-3d80-4ff4-968c-50aaffd1f844)

</td></tr><tr><td>

`focalCropAndResize`

![Screenshot 2025-06-24 at 3 51 50 pm](https://github.com/user-attachments/assets/8ff04151-cdcc-4769-8fc2-d2d7c622973d)

</td><td>

![Screenshot 2025-06-24 at 3 50 44 pm](https://github.com/user-attachments/assets/6a242705-49be-446f-857c-f55c9be1bab9)

</td></tr></table>
