### PR TITLE
Fix VipsDriver autoRotate with sequential access

### DIFF
--- a/src/Drivers/Vips/VipsDriver.php
+++ b/src/Drivers/Vips/VipsDriver.php
@@ -574,6 +574,15 @@ class VipsDriver implements ImageDriver
             return;
         }
 
+        if (
+            str_starts_with((string) $this->image->get('vips-loader'), 'jpegload')
+            && ! in_array($this->exif['Orientation'], [3, 5, 6, 7, 8])
+        ) {
+            // libvips cannot save rotated JPEG with sequential access so
+            // copy it into memory with random access
+            $this->image = $this->image->copyMemory();
+        }
+
         switch ($this->exif['Orientation']) {
             case 8:
                 $this->image = $this->image->rot90();

--- a/src/Drivers/Vips/VipsDriver.php
+++ b/src/Drivers/Vips/VipsDriver.php
@@ -574,13 +574,13 @@ class VipsDriver implements ImageDriver
             return;
         }
 
-        if (
-            str_starts_with((string) $this->image->get('vips-loader'), 'jpegload')
-            && ! in_array($this->exif['Orientation'], [3, 5, 6, 7, 8])
-        ) {
-            // libvips cannot save rotated JPEG with sequential access so
-            // copy it into memory with random access
-            $this->image = $this->image->copyMemory();
+        $loadedFromJpeg = str_starts_with((string) $this->image->get('vips-loader'), 'jpegload');
+        $needsRotation = in_array($this->exif['Orientation'], [3, 5, 6, 7, 8]);
+
+        if ($loadedFromJpeg) {
+            if ($needsRotation) {
+                $this->image = $this->image->copyMemory();
+            }
         }
 
         switch ($this->exif['Orientation']) {

--- a/tests/OrientationTest.php
+++ b/tests/OrientationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Jcupitt\Vips\Image as VipsImage;
 use Spatie\Image\Drivers\ImageDriver;
 use Spatie\Image\Image;
 use Spatie\Pixelmatch\Pixelmatch;
@@ -74,3 +75,30 @@ it('auto rotates all EXIF orientations to the same result', function (ImageDrive
             ->toBeTrue("Orientation {$orientation}: pixels don't match orientation 1");
     }
 })->with('drivers');
+
+it('auto rotates a large JPEG without an out of order read error', function (int $orientation, int $expectedWidth, int $expectedHeight) {
+    $sourceImage = VipsImage::black(2000, 1500)
+        ->add([120, 140, 160])
+        ->cast('uchar')
+        ->copy(['interpretation' => 'srgb']);
+
+    $sourceImage->set('orientation', $orientation);
+
+    $sourceFile = $this->tempDir->path("large-orientation-{$orientation}.jpg");
+    $sourceImage->writeToFile($sourceFile);
+
+    $targetFile = $this->tempDir->path("vips/large-orientation-{$orientation}.jpg");
+
+    Image::useImageDriver('vips')->loadFile($sourceFile)->save($targetFile);
+
+    [$width, $height] = getimagesize($targetFile);
+
+    expect($width)->toEqual($expectedWidth);
+    expect($height)->toEqual($expectedHeight);
+})->with([
+    'orientation 3' => [3, 2000, 1500],
+    'orientation 5' => [5, 1500, 2000],
+    'orientation 6' => [6, 1500, 2000],
+    'orientation 7' => [7, 1500, 2000],
+    'orientation 8' => [8, 1500, 2000],
+]);


### PR DESCRIPTION
According to libvips/libvips#4475 you can't rotate JPEGs with sequential access