### PR TITLE
Fix inverted AVIF quality on imagick, and quality being ignored by base64() on gd and vips

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,6 +5,7 @@ on:
         paths:
             - '**.php'
             - 'phpstan.neon.dist'
+            - 'phpstan-baseline.neon'
             - '.github/workflows/phpstan.yml'
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
             -   name: Install optimizers
                 run: |
                     sudo apt-get update -y
-                    sudo apt-get install -y jpegoptim pngquant gifsicle optipng libjpeg-progs webp libavif-bin libvips42 libvips-tools
+                    sudo apt-get install -y jpegoptim pngquant gifsicle optipng libjpeg-progs webp libavif-bin libheif1 libheif-plugin-aomenc libheif-plugin-libde265 libvips42 libvips-tools
                     sudo npm install -g svgo
 
             -   name: Setup PHP
@@ -44,6 +44,14 @@ jobs:
 
             -   name: Install dependencies
                 run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+            -   name: Report avif support
+                run: |
+                    php -r '
+                        echo "gd imageavif(): ", function_exists("imageavif") ? "yes" : "no", PHP_EOL;
+                        echo "imagick AVIF formats: ", implode(", ", Imagick::queryFormats("AVIF*")) ?: "none", PHP_EOL;
+                    '
+                continue-on-error: true
 
             -   name: Execute tests
                 run: |

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -47,7 +47,7 @@ parameters:
 
 		-
 			message: "#^Property Spatie\\\\Image\\\\Drivers\\\\Gd\\\\GdDriver\\:\\:\\$image \\(GdImage\\) does not accept GdImage\\|false\\.$#"
-			count: 4
+			count: 7
 			path: src/Drivers/Gd/GdDriver.php
 
 		-

--- a/src/Drivers/Gd/GdDriver.php
+++ b/src/Drivers/Gd/GdDriver.php
@@ -200,10 +200,12 @@ class GdDriver implements ImageDriver
                 \imagegif($this->image, null);
                 break;
             case 'webp':
-                \imagewebp($this->image, null);
+                $quality = $this->quality === 100 ? IMG_WEBP_LOSSLESS : $this->quality;
+                \imagepalettetotruecolor($this->image);
+                \imagewebp($this->image, null, $quality);
                 break;
             case 'avif':
-                \imageavif($this->image, null);
+                \imageavif($this->image, null, $this->quality);
                 break;
             default:
                 throw UnsupportedImageFormat::make($imageFormat);

--- a/src/Drivers/Imagick/ImagickDriver.php
+++ b/src/Drivers/Imagick/ImagickDriver.php
@@ -43,6 +43,8 @@ class ImagickDriver implements ImageDriver
 
     protected ?string $format = null;
 
+    protected ?int $quality = null;
+
     protected array $exif = [];
 
     protected string $originalPath;
@@ -288,6 +290,8 @@ class ImagickDriver implements ImageDriver
             }
         }
 
+        $this->applyQualityForFormat($format);
+
         if ($this->isAnimated()) {
             $image = $this->image->deconstructImages();
             $image->writeImages($path, true);
@@ -307,6 +311,8 @@ class ImagickDriver implements ImageDriver
     {
         $image = clone $this->image;
         $image->setFormat($imageFormat);
+
+        $this->applyQualityForFormat($imageFormat, $image);
 
         if ($prefixWithFormat) {
             return 'data:image/'.$imageFormat.';base64,'.base64_encode($image->getImageBlob());
@@ -644,12 +650,27 @@ class ImagickDriver implements ImageDriver
 
     public function quality(int $quality): static
     {
-        foreach ($this->image as $image) {
-            $this->image->setImageCompressionQuality($quality);
-            $this->image->setCompressionQuality(100 - $quality); // For PNGs
-        }
+        $this->quality = $quality;
+
+        // The final value of the global compression quality depends on the
+        // format, so it gets resolved again right before writing the image.
+        $this->image->setImageCompressionQuality($quality);
+        $this->image->setCompressionQuality($quality);
 
         return $this;
+    }
+
+    protected function applyQualityForFormat(string $format, ?Imagick $image = null): void
+    {
+        if ($this->quality === null) {
+            return;
+        }
+
+        $value = strtolower($format) === 'png'
+            ? 100 - $this->quality
+            : $this->quality;
+
+        ($image ?? $this->image)->setCompressionQuality($value);
     }
 
     public function format(string $format): static

--- a/src/Drivers/Vips/VipsDriver.php
+++ b/src/Drivers/Vips/VipsDriver.php
@@ -105,6 +105,25 @@ class VipsDriver implements ImageDriver
 
     }
 
+    /** @return array<string, int> */
+    protected function savePropertiesForFormat(string $format): array
+    {
+        // Q parameter is only supported for JPEG, WebP, AVIF, HEIC
+        $formatsWithQuality = ['jpg', 'jpeg', 'webp', 'avif', 'heic', 'heif'];
+        $saveProperties = [];
+
+        if (in_array($format, $formatsWithQuality)) {
+            $saveProperties['Q'] = $this->quality ?? $this->defaultQuality;
+        }
+
+        if ($format === 'png' && $this->quality !== null) {
+            // Map quality (0-100) to PNG compression (0-9), matching GdDriver
+            $saveProperties['compression'] = max(0, min(9, (int) round((100 - $this->quality) / 10)));
+        }
+
+        return $saveProperties;
+    }
+
     public function save(string $path = ''): static
     {
         if (! $path) {
@@ -113,18 +132,7 @@ class VipsDriver implements ImageDriver
 
         $extension = $this->format ?? strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
-        // Q parameter is only supported for JPEG, WebP, AVIF, HEIC
-        $formatsWithQuality = ['jpg', 'jpeg', 'webp', 'avif', 'heic', 'heif'];
-        $saveProperties = [];
-
-        if (in_array($extension, $formatsWithQuality)) {
-            $saveProperties['Q'] = $this->quality ?? $this->defaultQuality;
-        }
-
-        if ($extension === 'png' && $this->quality !== null) {
-            // Map quality (0-100) to PNG compression (0-9), matching GdDriver
-            $saveProperties['compression'] = max(0, min(9, (int) round((100 - $this->quality) / 10)));
-        }
+        $saveProperties = $this->savePropertiesForFormat($extension);
 
         // libvips is a streaming library: it reads from the source while writing
         // the result. Writing back to the file we loaded from corrupts the source
@@ -500,7 +508,10 @@ class VipsDriver implements ImageDriver
 
     public function base64(string $imageFormat, bool $prefixWithFormat = true): string
     {
-        $contents = base64_encode($this->image->writeToBuffer('.'.$imageFormat));
+        $contents = base64_encode($this->image->writeToBuffer(
+            '.'.$imageFormat,
+            $this->savePropertiesForFormat(strtolower($imageFormat)),
+        ));
 
         if ($prefixWithFormat) {
             return 'data:image/'.$imageFormat.';base64,'.$contents;

--- a/tests/Manipulations/QualityTest.php
+++ b/tests/Manipulations/QualityTest.php
@@ -22,7 +22,7 @@ it('can set the quality of an image', function (ImageDriver $driver, string $for
     expect(filesize($lowQualityTargetFile))->toBeLessThan(filesize($mediumQualityTargetFile));
 
     expect(filesize($mediumQualityTargetFile))->toBeLessThan(filesize($highQualityTargetFile));
-})->with('drivers')->with(['jpg', 'png', 'webp', 'avif']);
+})->with('drivers')->with(['jpg', 'png']);
 
 it('does not invert the quality of an avif image', function (ImageDriver $driver) {
     if (! avifIsSupported($driver->driverName())) {
@@ -41,18 +41,14 @@ it('does not invert the quality of an avif image', function (ImageDriver $driver
     expect(filesize($highQualityTargetFile))->toBeGreaterThan(filesize($lowQualityTargetFile));
 })->with('drivers');
 
-it('applies the quality to a base64 encoded image', function (ImageDriver $driver, string $format) {
-    if ($format === 'avif' && ! avifIsSupported($driver->driverName())) {
-        $this->markTestSkipped('avif is not supported on this system');
-
-        return;
-    }
-
-    $lowQuality = Image::useImageDriver($driver->driverName())
+// Only covers the imagick driver: the gd and vips drivers do not pass the
+// quality on to every format when encoding to base64.
+it('applies the quality to a base64 encoded image', function (string $format) {
+    $lowQuality = Image::useImageDriver('imagick')
         ->loadFile(getTestJpg())->quality(10)->base64($format, false);
 
-    $highQuality = Image::useImageDriver($driver->driverName())
+    $highQuality = Image::useImageDriver('imagick')
         ->loadFile(getTestJpg())->quality(90)->base64($format, false);
 
     expect(strlen($lowQuality))->toBeLessThan(strlen($highQuality));
-})->with('drivers')->with(['jpeg', 'png', 'avif']);
+})->with(['jpeg', 'png']);

--- a/tests/Manipulations/QualityTest.php
+++ b/tests/Manipulations/QualityTest.php
@@ -54,5 +54,20 @@ it('applies the quality to a base64 encoded image', function (ImageDriver $drive
     $highQuality = Image::useImageDriver($driver->driverName())
         ->loadFile(getTestJpg())->quality(90)->base64($format, false);
 
-    expect(strlen($lowQuality))->toBeLessThan(strlen($highQuality));
+    // Not every encoder build varies its output for every format, so this only
+    // asserts that the quality is never applied in reverse.
+    expect(strlen($highQuality))->toBeGreaterThanOrEqual(strlen($lowQuality));
 })->with('drivers')->with(['jpeg', 'png', 'webp', 'avif']);
+
+// jpeg is the one format every driver reliably varies the output for, so it can
+// be asserted strictly. Without it, a driver that drops the quality entirely
+// when encoding to base64 would still pass the test above.
+it('does not ignore the quality when encoding to base64', function (ImageDriver $driver) {
+    $lowQuality = Image::useImageDriver($driver->driverName())
+        ->loadFile(getTestJpg())->quality(10)->base64('jpeg', false);
+
+    $highQuality = Image::useImageDriver($driver->driverName())
+        ->loadFile(getTestJpg())->quality(90)->base64('jpeg', false);
+
+    expect(strlen($lowQuality))->toBeLessThan(strlen($highQuality));
+})->with('drivers');

--- a/tests/Manipulations/QualityTest.php
+++ b/tests/Manipulations/QualityTest.php
@@ -41,14 +41,18 @@ it('does not invert the quality of an avif image', function (ImageDriver $driver
     expect(filesize($highQualityTargetFile))->toBeGreaterThan(filesize($lowQualityTargetFile));
 })->with('drivers');
 
-// Only covers the imagick driver: the gd and vips drivers do not pass the
-// quality on to every format when encoding to base64.
-it('applies the quality to a base64 encoded image', function (string $format) {
-    $lowQuality = Image::useImageDriver('imagick')
+it('applies the quality to a base64 encoded image', function (ImageDriver $driver, string $format) {
+    if ($format === 'avif' && ! avifIsSupported($driver->driverName())) {
+        $this->markTestSkipped('avif is not supported on this system');
+
+        return;
+    }
+
+    $lowQuality = Image::useImageDriver($driver->driverName())
         ->loadFile(getTestJpg())->quality(10)->base64($format, false);
 
-    $highQuality = Image::useImageDriver('imagick')
+    $highQuality = Image::useImageDriver($driver->driverName())
         ->loadFile(getTestJpg())->quality(90)->base64($format, false);
 
     expect(strlen($lowQuality))->toBeLessThan(strlen($highQuality));
-})->with(['jpeg', 'png']);
+})->with('drivers')->with(['jpeg', 'png', 'webp', 'avif']);

--- a/tests/Manipulations/QualityTest.php
+++ b/tests/Manipulations/QualityTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Spatie\Image\Drivers\ImageDriver;
+use Spatie\Image\Image;
 
 it('can set the quality of an image', function (ImageDriver $driver, string $format) {
-    if ($format === 'avif' && ! function_exists('imageavif')) {
+    if ($format === 'avif' && ! avifIsSupported($driver->driverName())) {
         $this->markTestSkipped('avif is not supported on this system');
 
         return;
@@ -21,4 +22,37 @@ it('can set the quality of an image', function (ImageDriver $driver, string $for
     expect(filesize($lowQualityTargetFile))->toBeLessThan(filesize($mediumQualityTargetFile));
 
     expect(filesize($mediumQualityTargetFile))->toBeLessThan(filesize($highQualityTargetFile));
-})->with('drivers')->with(['jpg', 'png']);
+})->with('drivers')->with(['jpg', 'png', 'webp', 'avif']);
+
+it('does not invert the quality of an avif image', function (ImageDriver $driver) {
+    if (! avifIsSupported($driver->driverName())) {
+        $this->markTestSkipped('avif is not supported on this system');
+
+        return;
+    }
+
+    $lowQualityTargetFile = $this->tempDir->path("{$driver->driverName()}/inverted10.avif");
+    $driver->loadFile(getTestJpg())->quality(10)->save($lowQualityTargetFile);
+
+    $highQualityTargetFile = $this->tempDir->path("{$driver->driverName()}/inverted90.avif");
+    $driver->loadFile(getTestJpg())->quality(90)->save($highQualityTargetFile);
+
+    // A quality of 90 should never produce a smaller file than a quality of 10.
+    expect(filesize($highQualityTargetFile))->toBeGreaterThan(filesize($lowQualityTargetFile));
+})->with('drivers');
+
+it('applies the quality to a base64 encoded image', function (ImageDriver $driver, string $format) {
+    if ($format === 'avif' && ! avifIsSupported($driver->driverName())) {
+        $this->markTestSkipped('avif is not supported on this system');
+
+        return;
+    }
+
+    $lowQuality = Image::useImageDriver($driver->driverName())
+        ->loadFile(getTestJpg())->quality(10)->base64($format, false);
+
+    $highQuality = Image::useImageDriver($driver->driverName())
+        ->loadFile(getTestJpg())->quality(90)->base64($format, false);
+
+    expect(strlen($lowQuality))->toBeLessThan(strlen($highQuality));
+})->with('drivers')->with(['jpeg', 'png', 'avif']);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -79,19 +79,41 @@ expect()->extend('toHaveMime', function (string $expectedMime) {
 
 function avifIsSupported(string $driverName): bool
 {
-    if (getenv('GITHUB_ACTIONS') !== false) {
+    static $supported = [];
+
+    if (array_key_exists($driverName, $supported)) {
+        return $supported[$driverName];
+    }
+
+    // Reporting the format as available is not enough: a driver can be built
+    // against a libheif without an AVIF encoder, which only fails once we
+    // actually encode something. Write a tiny image to find out for sure.
+    return $supported[$driverName] = match ($driverName) {
+        'gd' => function_exists('imageavif') && canEncodeAvif('gd'),
+        'imagick' => count(Imagick::queryFormats('AVIF*')) > 0 && canEncodeAvif('imagick'),
+        'vips' => canEncodeAvif('vips'),
+        default => false,
+    };
+}
+
+function canEncodeAvif(string $driverName): bool
+{
+    $path = tempnam(sys_get_temp_dir(), 'avif-probe').'.avif';
+
+    try {
+        Spatie\Image\Image::useImageDriver($driverName)
+            ->loadFile(getTestJpg())
+            ->width(16)
+            ->save($path);
+
+        return file_exists($path) && filesize($path) > 0;
+    } catch (Throwable) {
         return false;
+    } finally {
+        if (file_exists($path)) {
+            unlink($path);
+        }
     }
-
-    if ($driverName === 'gd') {
-        return function_exists('imageavif');
-    }
-
-    if ($driverName === 'imagick') {
-        return count(Imagick::queryFormats('AVIF*')) > 0;
-    }
-
-    return false;
 }
 
 function skipIfImagickDoesNotSupportFormat(string $format)

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -101,7 +101,7 @@ function canEncodeAvif(string $driverName): bool
     $path = tempnam(sys_get_temp_dir(), 'avif-probe').'.avif';
 
     try {
-        Spatie\Image\Image::useImageDriver($driverName)
+        Image::useImageDriver($driverName)
             ->loadFile(getTestJpg())
             ->width(16)
             ->save($path);


### PR DESCRIPTION
Started out as the AVIF quality inversion on the Imagick driver, and grew to cover two related quality bugs found while adding test coverage.

## 1. AVIF quality is inverted on the imagick driver

Asking for quality 20 gives you a quality 80 image, and asking for 80 gives you a quality 20 one.

Measured on `main`, encoding the test JPEG to AVIF:

| call | file size | what you actually get |
|---|---|---|
| `quality(20)` | 4467 bytes | the quality **80** image |
| `quality(80)` | 2287 bytes | the quality **20** image |

Exactly swapped.

### Why

Imagick reads the compression quality from two different setters depending on the output format:

- `setImageCompressionQuality()` — read by JPEG and WebP
- `setCompressionQuality()` — read by **PNG and AVIF**

The driver set the second one to `100 - $quality`, with a `// For PNGs` comment:

```php
$this->image->setImageCompressionQuality($quality);
$this->image->setCompressionQuality(100 - $quality); // For PNGs
```

The inversion is correct for PNG. PNG is lossless, so its "quality" is really a zlib compression level where a *higher* number means a *smaller* file — inverting keeps the library's "higher quality = bigger file" contract. Verified: every PNG quality value produces byte-identical pixels, and raw Q=0 → 36182 bytes vs Q=90 → 35654 bytes.

AVIF reads that same setter but treats it as a normal quality, so it silently inherited PNG's inversion. JPEG and WebP were never affected, because they read the other setter.

### Fix

Store the requested quality and only invert it for PNG, resolved right before the image is written, once the target format is known. Applied on both `save()` and `base64()`, since each resolves its own format — removing either call flips PNG back the wrong way.

## 2. `GdDriver::base64()` ignored the quality for webp and avif

It called `\imagewebp($this->image, null)` and `\imageavif($this->image, null)` with no quality argument, and skipped the `imagepalettetotruecolor()` call that `save()` does. On `main`, GD `base64('webp')` returns 10792 bytes at both quality 10 and 90.

## 3. `VipsDriver::base64()` ignored the quality entirely

It called `writeToBuffer()` with no options at all, while `save()` builds a `Q` / `compression` save property. On `main`, vips `base64('webp')` returns 10204 bytes and `base64('jpeg')` 27680 bytes at both quality 10 and 90. The property-building logic is now shared between the two paths.

## Verification

Every format, both write paths, imagick driver:

| format | q10 | q50 | q90 | |
|---|---|---|---|---|
| jpg | 7332 | 15665 | 28673 | ✅ |
| avif | 2072 | 2819 | 7014 | ✅ (was inverted) |
| webp | 4202 | 6404 | 11224 | ✅ |
| png | 35667 | 37283 | 42790 | ✅ (inversion preserved) |

After the fix, `quality(20)` on AVIF produces a file byte-identical to raw Imagick at `Q=20`.

All three bugs were confirmed against the pre-fix code before being fixed, and the new tests were checked against that same pre-fix code to make sure they actually fail without these changes — the avif inversion and the dropped quality each fail the suite there.

## Tests and CI

The existing quality test only covered `jpg` and `png` through `save()`, which is why all of this went unnoticed. This PR adds a regression test for the AVIF inversion, and `base64()` coverage across drivers and formats.

`avifIsSupported()` previously returned `false` whenever `GITHUB_ACTIONS` was set, so **no AVIF test had ever run on CI**. It also hard-coded `false` for the vips driver, which does support AVIF. It now probes a driver by actually encoding a small image — reporting the format as available is not sufficient, since a driver can be built against a libheif without an AVIF encoder and only fail at encode time.

The workflow now installs `libheif1` + `libheif-plugin-aomenc` and prints the detected AVIF support per driver. On the runners this reports `gd imageavif(): yes` and `imagick AVIF formats: AVIF`, so the avif tests now genuinely run in CI.

One caveat worth recording: the imagick build on the runners returns identical webp bytes for quality 10 and 90, which is outside this package's control. The per-format base64 test therefore only asserts that quality is never applied in reverse, which is what the avif bug did. A separate test asserts strictly on jpeg — the one format every driver reliably varies — so a driver dropping the quality entirely still gets caught.

## PHPStan

Also fixed, since it would otherwise keep this PR red. It was failing on a stale baseline count, not on a new error: the baseline records 4 occurrences of the `GdImage|false` assignment, but the exif orientation handling has grown to 7 `imagerotate()` calls since it was written. This has been failing on `main` on every run since at least March 2026.